### PR TITLE
Harmonise text measurement methods

### DIFF
--- a/InfoBox/Form/InformationBoxForm.cs
+++ b/InfoBox/Form/InformationBoxForm.cs
@@ -75,11 +75,6 @@ namespace InfoBox
         private readonly string doNotShowAgainText;
 
         /// <summary>
-        /// Contains the graphics used to measure the strings
-        /// </summary>
-        private readonly Graphics measureGraphics;
-
-        /// <summary>
         /// Contains a reference to the active form
         /// </summary>
         private readonly Form activeForm;
@@ -288,8 +283,6 @@ namespace InfoBox
                                     InformationBoxSound sound = InformationBoxSound.Default)
         {
             this.InitializeComponent();
-            this.measureGraphics = CreateGraphics();
-            this.measureGraphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
 
             // Apply default font for message boxes
             this.Font = SystemFonts.MessageBoxFont;
@@ -1007,7 +1000,7 @@ namespace InfoBox
             #region Width
 
             // Caption width including button
-            int captionWidth = Convert.ToInt32(this.measureGraphics.MeasureString(Text, SystemFonts.CaptionFont).Width) + 30;
+            int captionWidth = TextRenderer.MeasureText(Text, SystemFonts.CaptionFont, Size.Empty, TextFormatFlags.NoPadding | TextFormatFlags.NoPrefix).Width + 30;
             if (this.titleStyle != InformationBoxTitleIconStyle.None)
             {
                 captionWidth += BorderPadding * 2;
@@ -1015,7 +1008,7 @@ namespace InfoBox
 
             // "Do not show this dialog again" width
             int checkBoxWidth = ((this.checkBox & InformationBoxCheckBox.Show) == InformationBoxCheckBox.Show)
-                                    ? (int)this.measureGraphics.MeasureString(this.chbDoNotShow.Text, this.chbDoNotShow.Font).Width + BorderPadding * 4
+                                    ? TextRenderer.MeasureText(this.chbDoNotShow.Text, this.chbDoNotShow.Font, Size.Empty, TextFormatFlags.NoPadding).Width + BorderPadding * 4
                                     : 0;
 
             // Width of the text and icon.
@@ -1273,7 +1266,7 @@ namespace InfoBox
                 if (this.autoSizeMode == InformationBoxAutoSizeMode.None)
                 {
                     this.messageText.WordWrap = true;
-                    this.messageText.Size = (this.measureGraphics.MeasureString(this.messageText.Text, this.messageText.Font, screenWidth / 2) + new SizeF(1, 0)).ToSize();
+                    this.messageText.Size = TextRenderer.MeasureText(this.messageText.Text, this.messageText.Font, new Size(screenWidth / 2, 0), TextFormatFlags.TextBoxControl | TextFormatFlags.WordBreak);
                 }
                 else
                 {
@@ -1290,7 +1283,7 @@ namespace InfoBox
 
                         foreach (Match sentence in sentences)
                         {
-                            int sentenceLength = (int)this.measureGraphics.MeasureString(sentence.Value, this.messageText.Font).Width;
+                            int sentenceLength = TextRenderer.MeasureText(sentence.Value, this.messageText.Font, Size.Empty, TextFormatFlags.TextBoxControl | TextFormatFlags.NoPadding).Width;
                             if (currentWidth != 0 && (sentenceLength + currentWidth) > (screenWidth - 50))
                             {
                                 formattedText.Append(Environment.NewLine);
@@ -1315,7 +1308,7 @@ namespace InfoBox
 
                     this.messageText.Text = this.internalText.ToString();
 
-                    this.messageText.Size = (this.measureGraphics.MeasureString(this.messageText.Text, this.messageText.Font) + new SizeF(1, 0)).ToSize();
+                    this.messageText.Size = TextRenderer.MeasureText(this.messageText.Text, this.messageText.Font, Size.Empty, TextFormatFlags.TextBoxControl);
                 }
             }
 
@@ -1426,7 +1419,7 @@ namespace InfoBox
             // Measures the width of each button
             foreach (Control ctrl in this.pnlButtons.Controls)
             {
-                maxSize = Math.Max(Convert.ToInt32(this.measureGraphics.MeasureString(ctrl.Text, ctrl.Font).Width + 40), maxSize);
+                maxSize = Math.Max(TextRenderer.MeasureText(ctrl.Text, ctrl.Font, Size.Empty, TextFormatFlags.NoPadding | TextFormatFlags.NoPrefix).Width + 40, maxSize);
             }
 
             foreach (Control ctrl in this.pnlButtons.Controls)

--- a/InfoBox/InfoBox.nuspec
+++ b/InfoBox/InfoBox.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>InformationBox</id>
-        <version>1.0.0</version>
+        <version>1.4.0</version>
         <title>InformationBox</title>
         <authors>Johann Blais</authors>
         <owners>Johann Blais</owners>
@@ -15,10 +15,11 @@
 InformationBox is the simplest and easiest way to create personalized MessageBox.
 
 Stop wasting time developing your own custom MessageBox, everything you need is already available. Just customize your MessageBox using the visual designer and the code is automatically generated !</description>
-        <summary>InformationBox (.NET 4.0+) is a flexible alternative to the default MessageBox included in the System.Windows.Forms namespace</summary>
+        <summary>InformationBox (.NET 4.8+, dotnet core  8.0+) is a flexible alternative to the default MessageBox included in the System.Windows.Forms namespace</summary>
         <releaseNotes>
-            - Removed support for .NET 6.0 (Windows)
-            - Added support for .NET 10.0 (Windows)
+            - Improved text measurement accuracy by migrating from Graphics.MeasureString (GDI+) to TextRenderer.MeasureText (GDI)
+            - Removed Graphics dependency for better testability
+            - Text sizing now matches actual TextBox rendering more accurately
         </releaseNotes>
         <copyright>Copyright 2026</copyright>
         <language>en-US</language>

--- a/InfoBox/Properties/AssemblyInfo.cs
+++ b/InfoBox/Properties/AssemblyInfo.cs
@@ -42,11 +42,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Revision and Build Numbers 
+// You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]


### PR DESCRIPTION
Removed usage of the Graphics.MeasureString and used TextRenderer.MeasureText instead