### PR TITLE
Decouple configuration/state of the InfoBox from the form itself

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,12 @@ The solution uses a dual-build strategy with shared source code:
 - **InfoBox.Designer/** - Visual designer tool (.NET Framework 4.8)
 - **InfoBoxCore.Designer/** - Visual designer tool (.NET 8/9/10)
 - **InfoBoxCore.Designer.Tests/** - NUnit tests for code generation
+- **InfoBoxCore.Tests/** - NUnit tests for ViewModel and parameter parsing logic
 
 Both InfoBox and InfoBoxCore compile to the same assembly name (`InfoBox.dll`) and namespace (`InfoBox`).
+
+### Adding New Source Files
+**InfoBox/** uses legacy .csproj format — new `.cs` files must be manually added as `<Compile Include="..." />` entries. InfoBoxCore auto-includes them via wildcard `<Compile Include="..\InfoBox\**\*.cs" />`.
 
 ## Key Architecture
 
@@ -57,6 +61,12 @@ The main API `InformationBox.Show()` accepts parameters in any order via `params
 - `InfoBox/Enums/` - Configuration enums (buttons, icons, position, etc.)
 - `InfoBox/Context/InformationBoxScope.cs` - Scope-based default configuration
 
+### ViewModel Architecture
+- `InfoBox/Internals/InformationBoxViewModel.cs` - Configuration state and business logic (testable without WinForms)
+- `InfoBox/Internals/ParameterParser.cs` - Parses `params object[]` and named parameters into a ViewModel
+- `InfoBox/Internals/ViewModelTypes.cs` - DTOs returned by ViewModel methods (`ButtonDefinition`, `CheckBoxConfiguration`, etc.)
+- `InfoBox/Internals/ITextMeasurer.cs` / `IScreenProvider.cs` - Abstractions for testability
+
 ### Code Generation
 The Designer tool generates C# or VB.NET code:
 - `InfoBox.Designer/CodeGeneration/CSharpGenerator.cs`
@@ -67,3 +77,8 @@ Tests use Roslyn to compile and validate generated code.
 ## Localization
 
 Resources are in `InfoBox/Properties/Resources.*.resx` with support for: English, German, Spanish, French, Portuguese, Arabic, Farsi, Dutch.
+
+## Gotchas
+
+- `params object[]` and `string[]`: Passing `string[]` to a `params object[]` method expands each string as a separate parameter. Cast to `(object)` to pass the array as a single element.
+- `DesignParameters` constructor order is `(formBackColor, barsBackColor)` — form color first, bars color second.

--- a/InfoBox/Form/InformationBoxForm.cs
+++ b/InfoBox/Form/InformationBoxForm.cs
@@ -45,39 +45,9 @@ namespace InfoBox
         private float dpiScale;
 
         /// <summary>
-        /// Contains the callback used to inform the caller of a modeless box
+        /// Contains the viewmodel holding all configuration and business logic
         /// </summary>
-        private readonly AsyncResultCallback callback;
-
-        /// <summary>
-        /// Text for the first user button
-        /// </summary>
-        private readonly string buttonUser1Text = "User1";
-
-        /// <summary>
-        /// Text for the second user button
-        /// </summary>
-        private readonly string buttonUser2Text = "User2";
-
-        /// <summary>
-        /// Text for the third user button
-        /// </summary>
-        private readonly string buttonUser3Text = "User3";
-
-        /// <summary>
-        /// Help file associated to the help button
-        /// </summary>
-        private readonly string helpFile;
-
-        /// <summary>
-        /// Help topic associated to the help button
-        /// </summary>
-        private readonly string helpTopic;
-
-        /// <summary>
-        /// Text for the "Do not show again" checkbox
-        /// </summary>
-        private readonly string doNotShowAgainText;
+        private readonly InformationBoxViewModel viewModel;
 
         /// <summary>
         /// Contains a reference to the active form
@@ -88,101 +58,6 @@ namespace InfoBox
         /// Result corresponding the clicked button
         /// </summary>
         private InformationBoxResult result = InformationBoxResult.None;
-
-        /// <summary>
-        /// Main icon of the form
-        /// </summary>
-        private InformationBoxIcon icon;
-
-        /// <summary>
-        /// Custom icon
-        /// </summary>
-        private Icon customIcon;
-
-        /// <summary>
-        /// Buttons displayed on the form
-        /// </summary>
-        private InformationBoxButtons buttons;
-
-        /// <summary>
-        /// Default button
-        /// </summary>
-        private InformationBoxDefaultButton defaultButton;
-
-        /// <summary>
-        /// Buttons layout
-        /// </summary>
-        private InformationBoxButtonsLayout buttonsLayout = InformationBoxButtonsLayout.GroupMiddle;
-
-        /// <summary>
-        /// Contains the autosize mode
-        /// </summary>
-        private InformationBoxAutoSizeMode autoSizeMode = InformationBoxAutoSizeMode.None;
-
-        /// <summary>
-        /// Contains the box initial position
-        /// </summary>
-        private InformationBoxPosition position = InformationBoxPosition.CenterOnParent;
-
-        /// <summary>
-        /// Contains a value defining whether displaying the checkbox or not
-        /// </summary>
-        private InformationBoxCheckBox checkBox = 0;
-
-        /// <summary>
-        /// Contains the style of the box
-        /// </summary>
-        private InformationBoxStyle style = InformationBoxStyle.Standard;
-
-        /// <summary>
-        /// Contains the autoclose parameters
-        /// </summary>
-        private AutoCloseParameters autoClose;
-
-        /// <summary>
-        /// Contains the design parameters
-        /// </summary>
-        private DesignParameters design;
-
-        /// <summary>
-        /// Contains the font parameters
-        /// </summary>
-        private FontParameters fontParameters;
-
-        /// <summary>
-        /// Contains the style of the title
-        /// </summary>
-        private InformationBoxTitleIconStyle titleStyle = InformationBoxTitleIconStyle.None;
-
-        /// <summary>
-        /// Contains the title icon
-        /// </summary>
-        private Icon titleIcon;
-
-        /// <summary>
-        /// Contains if the box is modal or not
-        /// </summary>
-        private InformationBoxBehavior behavior = InformationBoxBehavior.Modal;
-
-        /// <summary>
-        /// Contains the opacity of the form
-        /// </summary>
-        private InformationBoxOpacity opacity = InformationBoxOpacity.NoFade;
-
-        /// <summary>
-        /// Contains the icon type
-        /// </summary>
-        private IconType iconType = IconType.Internal;
-
-        /// <summary>
-        /// Contains if the help button should be displayed
-        /// </summary>
-        private bool showHelpButton;
-
-        /// <summary>
-        /// Help navigator associated to the help button
-        /// </summary>
-        private HelpNavigator helpNavigator = HelpNavigator.TableOfContents;
 
         /// <summary>
         /// Contains whether a mouse button is down
@@ -199,16 +74,6 @@ namespace InfoBox
         /// </summary>
         private int elapsedTime;
 
-        /// <summary>
-        /// Z-Order of the form
-        /// </summary>
-        private InformationBoxOrder order = InformationBoxOrder.Default;
-
-        /// <summary>
-        /// Sound to play on opening
-        /// </summary>
-        private InformationBoxSound sound;
-
         #endregion Attributes
 
         #region Constructors
@@ -218,6 +83,28 @@ namespace InfoBox
         /// </summary>
         private InformationBoxForm()
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InformationBoxForm"/> class using a pre-built viewmodel.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel containing all configuration.</param>
+        internal InformationBoxForm(InformationBoxViewModel viewModel)
+        {
+            this.InitializeComponent();
+            this.dpiScale = this.DeviceDpi / 96f;
+
+            this.Font = SystemFonts.MessageBoxFont;
+            this.messageText.Font = SystemFonts.MessageBoxFont;
+            this.lblTitle.Font = SystemFonts.CaptionFont;
+
+            this.viewModel = viewModel;
+            this.activeForm = ActiveForm;
+
+            this.messageText.Text = viewModel.Text;
+            this.Text = viewModel.Title;
+            this.lblTitle.Text = viewModel.Title;
+            this.Parent = viewModel.Parent;
         }
 
         /// <summary>
@@ -287,85 +174,11 @@ namespace InfoBox
                                     Form parent = null,
                                     InformationBoxOrder order = InformationBoxOrder.Default,
                                     InformationBoxSound sound = InformationBoxSound.Default)
+            : this(ParameterParser.ParseNamed(text, title, helpFile, helpTopic, initialization, buttons, icon, customIcon,
+                defaultButton, customButtons, buttonsLayout, autoSizeMode, position, showHelpButton, helpNavigator,
+                showDoNotShowAgainCheckBox, doNotShowAgainText, style, autoClose, design, fontParameters, null, titleStyle,
+                titleIcon, legacyButtons, legacyIcon, legacyDefaultButton, behavior, callback, opacity, parent, order, sound))
         {
-            this.InitializeComponent();
-            this.dpiScale = this.DeviceDpi / 96f;
-
-            // Apply default font for message boxes
-            this.Font = SystemFonts.MessageBoxFont;
-            this.messageText.Font = SystemFonts.MessageBoxFont;
-            this.lblTitle.Font = SystemFonts.CaptionFont;
-
-            this.messageText.Text = text;
-
-            if (InformationBoxInitialization.FromParametersOnly == initialization)
-            {
-                this.LoadCurrentScope();
-            }
-
-            this.Text = title;
-            this.lblTitle.Text = title;
-            this.helpFile = helpFile;
-            this.helpTopic = helpTopic;
-            this.buttons = buttons;
-            this.icon = icon;
-            if (customIcon != null)
-            {
-                this.iconType = IconType.UserDefined;
-                this.customIcon = customIcon;
-            }
-            this.defaultButton = defaultButton;
-            if (customButtons != null)
-            {
-                if (customButtons.Length > 0)
-                {
-                    this.buttonUser1Text = customButtons[0];
-                }
-
-                if (customButtons.Length > 1)
-                {
-                    this.buttonUser2Text = customButtons[1];
-                }
-
-                if (customButtons.Length > 2)
-                {
-                    this.buttonUser3Text = customButtons[2];
-                }
-            }
-            this.buttonsLayout = buttonsLayout;
-            this.autoSizeMode = autoSizeMode;
-            this.position = position;
-            this.showHelpButton = showHelpButton;
-            this.helpNavigator = helpNavigator;
-            this.checkBox = showDoNotShowAgainCheckBox;
-            this.doNotShowAgainText = doNotShowAgainText;
-            this.style = style;
-            this.autoClose = autoClose;
-            this.design = design;
-            this.fontParameters = fontParameters;
-            this.titleStyle = titleStyle;
-            if (titleIcon != null)
-            {
-                this.titleIcon = titleIcon.Icon;
-            }
-            if (!(legacyButtons is null))
-            {
-                this.buttons = MessageBoxEnumConverter.Parse(legacyButtons.Value);
-            }
-            if (!(legacyIcon is null))
-            {
-                this.icon = MessageBoxEnumConverter.Parse(legacyIcon.Value);
-            }
-            if (!(legacyDefaultButton is null))
-            {
-                this.defaultButton = MessageBoxEnumConverter.Parse(legacyDefaultButton.Value);
-            }
-            this.behavior = behavior;
-            this.callback = callback;
-            this.opacity = opacity;
-            this.Parent = parent;
-            this.order = order;
-            this.sound = sound;
         }
 
         /// <summary>
@@ -374,215 +187,8 @@ namespace InfoBox
         /// <param name="text">The text of the box.</param>
         /// <param name="parameters">The parameters.</param>
         internal InformationBoxForm(string text, params object[] parameters)
-            : this(text)
+            : this(ParameterParser.Parse(text, parameters))
         {
-            this.activeForm = ActiveForm;
-
-            // Looks for a parameter of the type InformationBoxInitialization.
-            // If found and equal to InformationBoxInitialization.FromParametersOnly,
-            // skips the scope parameters.
-            bool loadScope = true;
-            foreach (object param in parameters)
-            {
-                if (param is InformationBoxInitialization)
-                {
-                    InformationBoxInitialization value = (InformationBoxInitialization)param;
-                    if (InformationBoxInitialization.FromParametersOnly == value)
-                    {
-                        loadScope = false;
-                    }
-                }
-            }
-
-            if (loadScope)
-            {
-                this.LoadCurrentScope();
-            }
-
-            int stringCount = 0;
-
-            foreach (object parameter in parameters)
-            {
-                if (null == parameter)
-                {
-                    continue;
-                }
-
-                // Simple string -> caption
-                // Or Help file if the string contains a file name
-                if (parameter is string)
-                {
-                    if (stringCount == 0)
-                    {
-                        this.Text = (string)parameter;
-                        this.lblTitle.Text = (string)parameter;
-                    }
-                    else if (stringCount == 1)
-                    {
-                        this.helpFile = (string)parameter;
-                    }
-                    else if (stringCount == 2)
-                    {
-                        this.helpTopic = (string)parameter;
-                    }
-                    else if (stringCount == 3)
-                    {
-                        this.doNotShowAgainText = (string)parameter;
-                    }
-
-                    stringCount++;
-                }
-                else if (parameter is InformationBoxButtons)
-                {
-                    // Buttons
-                    this.buttons = (InformationBoxButtons)parameter;
-                }
-                else if (parameter is InformationBoxIcon)
-                {
-                    // Internal icon
-                    this.icon = (InformationBoxIcon)parameter;
-                }
-                else if (parameter is Icon)
-                {
-                    // User defined icon
-                    this.iconType = IconType.UserDefined;
-                    this.customIcon = (Icon)parameter;
-                }
-                else if (parameter is InformationBoxDefaultButton)
-                {
-                    // Default button
-                    this.defaultButton = (InformationBoxDefaultButton)parameter;
-                }
-                else if (parameter is string[])
-                {
-                    // Custom buttons
-                    string[] labels = (string[])parameter;
-                    if (labels.Length > 0)
-                    {
-                        this.buttonUser1Text = labels[0];
-                    }
-
-                    if (labels.Length > 1)
-                    {
-                        this.buttonUser2Text = labels[1];
-                    }
-
-                    if (labels.Length > 2)
-                    {
-                        this.buttonUser3Text = labels[2];
-                    }
-                }
-                else if (parameter is InformationBoxButtonsLayout)
-                {
-                    // Buttons layout
-                    this.buttonsLayout = (InformationBoxButtonsLayout)parameter;
-                }
-                else if (parameter is InformationBoxAutoSizeMode)
-                {
-                    // Autosize mode
-                    this.autoSizeMode = (InformationBoxAutoSizeMode)parameter;
-                }
-                else if (parameter is InformationBoxPosition)
-                {
-                    // Position
-                    this.position = (InformationBoxPosition)parameter;
-                }
-                else if (parameter is bool)
-                {
-                    // Help button
-                    this.showHelpButton = (bool)parameter;
-                }
-                else if (parameter is HelpNavigator)
-                {
-                    // Help navigator
-                    this.helpNavigator = (HelpNavigator)parameter;
-                }
-                else if (parameter is InformationBoxCheckBox)
-                {
-                    // Do not show this dialog again ?
-                    this.checkBox = (InformationBoxCheckBox)parameter;
-                }
-                else if (parameter is InformationBoxStyle)
-                {
-                    // Visual style
-                    this.style = (InformationBoxStyle)parameter;
-                }
-                else if (parameter is AutoCloseParameters)
-                {
-                    // Auto-close parameters
-                    this.autoClose = (AutoCloseParameters)parameter;
-                }
-                else if (parameter is DesignParameters)
-                {
-                    // Design parameters
-                    this.design = (DesignParameters)parameter;
-                }
-                else if (parameter is FontParameters)
-                {
-                    // Font parameters
-                    this.fontParameters = (FontParameters)parameter;
-                }
-                else if (parameter is Font)
-                {
-                    // Direct font parameter - use for both message and title
-                    this.fontParameters = new FontParameters((Font)parameter);
-                }
-                else if (parameter is InformationBoxTitleIconStyle)
-                {
-                    // Title style
-                    this.titleStyle = (InformationBoxTitleIconStyle)parameter;
-                }
-                else if (parameter is InformationBoxTitleIcon)
-                {
-                    // Title icon
-                    this.titleIcon = ((InformationBoxTitleIcon)parameter).Icon;
-                }
-                else if (parameter is MessageBoxButtons?)
-                {
-                    // MessageBox buttons
-                    this.buttons = MessageBoxEnumConverter.Parse((MessageBoxButtons)parameter);
-                }
-                else if (parameter is MessageBoxIcon?)
-                {
-                    // MessageBox icon
-                    this.icon = MessageBoxEnumConverter.Parse((MessageBoxIcon)parameter);
-                }
-                else if (parameter is MessageBoxDefaultButton?)
-                {
-                    // MessageBox default button
-                    this.defaultButton = MessageBoxEnumConverter.Parse((MessageBoxDefaultButton)parameter);
-                }
-                else if (parameter is InformationBoxBehavior)
-                {
-                    // InformationBox behaviour
-                    this.behavior = (InformationBoxBehavior)parameter;
-                }
-                else if (parameter is AsyncResultCallback)
-                {
-                    // Callback for the result
-                    this.callback = (AsyncResultCallback)parameter;
-                }
-                else if (parameter is InformationBoxOpacity)
-                {
-                    // Opacity
-                    this.opacity = (InformationBoxOpacity)parameter;
-                }
-                else if (parameter is Form)
-                {
-                    // Form parent
-                    this.Parent = (Form)Parent;
-                }
-                else if (parameter is InformationBoxOrder)
-                {
-                    // z-order
-                    this.order = (InformationBoxOrder)parameter;
-                }
-                else if (parameter is InformationBoxSound)
-                {
-                    // Sound
-                    this.sound = (InformationBoxSound)parameter;
-                }
-            }
         }
 
         #endregion Constructors
@@ -595,21 +201,21 @@ namespace InfoBox
         /// <returns>The result corresponding to the button clicked</returns>
         internal new InformationBoxResult Show()
         {
-            this.SetCheckBox();
-            this.SetButtons();
-            this.SetFont();
-            this.SetText();
-            this.SetIcon();
-            this.SetLayout();
-            this.SetFocus();
-            this.SetPosition();
-            this.SetWindowStyle();
-            this.SetAutoClose();
-            this.SetOpacity();
+            this.ApplyCheckBox();
+            this.ApplyButtons();
+            this.ApplyFont();
+            this.ApplyText();
+            this.ApplyIcon();
+            this.ApplyLayout();
+            this.ApplyFocus();
+            this.ApplyPosition();
+            this.ApplyWindowStyle();
+            this.ApplyAutoClose();
+            this.ApplyOpacity();
             this.PlaySound();
-            this.SetOrder();
+            this.ApplyOrder();
 
-            if (this.behavior == InformationBoxBehavior.Modal)
+            if (this.viewModel.Behavior == InformationBoxBehavior.Modal)
             {
                 ShowDialog();
             }
@@ -642,39 +248,7 @@ namespace InfoBox
         /// </summary>
         private void PlaySound()
         {
-            if (sound == InformationBoxSound.None)
-            {
-                return;
-            }
-
-            SystemSound soundToPlay;
-
-            if (this.iconType == IconType.UserDefined)
-            {
-                soundToPlay = SystemSounds.Beep;
-            }
-            else
-            {
-                switch (IconHelper.GetCategory(this.icon))
-                {
-                    case InformationBoxMessageCategory.Asterisk:
-                        soundToPlay = SystemSounds.Asterisk;
-                        break;
-                    case InformationBoxMessageCategory.Exclamation:
-                        soundToPlay = SystemSounds.Exclamation;
-                        break;
-                    case InformationBoxMessageCategory.Hand:
-                        soundToPlay = SystemSounds.Hand;
-                        break;
-                    case InformationBoxMessageCategory.Question:
-                        soundToPlay = SystemSounds.Question;
-                        break;
-                    default:
-                        soundToPlay = SystemSounds.Beep;
-                        break;
-                }
-            }
-
+            SystemSound soundToPlay = this.viewModel.GetSystemSound();
             if (null != soundToPlay)
             {
                 soundToPlay.Play();
@@ -690,128 +264,14 @@ namespace InfoBox
 
         #region Box initialization
 
-        /// <summary>
-        /// Loads the current scope.
-        /// </summary>
-        private void LoadCurrentScope()
-        {
-            if (InformationBoxScope.Current == null)
-            {
-                return;
-            }
-
-            InformationBoxScopeParameters parameters = InformationBoxScope.Current.Parameters;
-
-            if (parameters.Icon.HasValue)
-            {
-                this.icon = parameters.Icon.Value;
-            }
-
-            if (parameters.CustomIcon != null)
-            {
-                this.iconType = IconType.UserDefined;
-                this.customIcon = parameters.CustomIcon;
-            }
-
-            if (parameters.Buttons.HasValue)
-            {
-                this.buttons = parameters.Buttons.Value;
-            }
-
-            if (parameters.DefaultButton.HasValue)
-            {
-                this.defaultButton = parameters.DefaultButton.Value;
-            }
-
-            if (parameters.Layout.HasValue)
-            {
-                this.buttonsLayout = parameters.Layout.Value;
-            }
-
-            if (parameters.AutoSizeMode.HasValue)
-            {
-                this.autoSizeMode = parameters.AutoSizeMode.Value;
-            }
-
-            if (parameters.Position.HasValue)
-            {
-                this.position = parameters.Position.Value;
-            }
-
-            if (parameters.CheckBox.HasValue)
-            {
-                this.checkBox = parameters.CheckBox.Value;
-            }
-
-            if (parameters.Style.HasValue)
-            {
-                this.style = parameters.Style.Value;
-            }
-
-            if (parameters.AutoClose != null)
-            {
-                this.autoClose = parameters.AutoClose;
-            }
-
-            if (parameters.Design != null)
-            {
-                this.design = parameters.Design;
-            }
-
-            if (parameters.Font != null)
-            {
-                this.fontParameters = parameters.Font;
-            }
-
-            if (parameters.TitleIconStyle.HasValue)
-            {
-                this.titleStyle = parameters.TitleIconStyle.Value;
-            }
-
-            if (parameters.TitleIcon != null)
-            {
-                this.titleIcon = parameters.TitleIcon;
-            }
-
-            if (parameters.Behavior.HasValue)
-            {
-                this.behavior = parameters.Behavior.Value;
-            }
-
-            if (parameters.Opacity.HasValue)
-            {
-                this.opacity = parameters.Opacity.Value;
-            }
-
-            if (parameters.Help.HasValue)
-            {
-                this.showHelpButton = parameters.Help.Value;
-            }
-
-            if (parameters.HelpNavigator.HasValue)
-            {
-                this.helpNavigator = parameters.HelpNavigator.Value;
-            }
-
-            if (parameters.Order.HasValue)
-            {
-                this.order = parameters.Order.Value;
-            }
-
-            if (parameters.Sound.HasValue)
-            {
-                this.sound = parameters.Sound.Value;
-            }
-        }
-
         #region Auto close
 
         /// <summary>
         /// Sets the auto close parameters.
         /// </summary>
-        private void SetAutoClose()
+        private void ApplyAutoClose()
         {
-            if (null == this.autoClose)
+            if (null == this.viewModel.AutoClose)
             {
                 return;
             }
@@ -826,45 +286,11 @@ namespace InfoBox
         #region Opacity
 
         /// <summary>
-        /// Sets the opacity.
+        /// Applies the opacity.
         /// </summary>
-        private void SetOpacity()
+        private void ApplyOpacity()
         {
-            switch (this.opacity)
-            {
-                case InformationBoxOpacity.Faded10:
-                    Opacity = 0.1;
-                    break;
-                case InformationBoxOpacity.Faded20:
-                    Opacity = 0.2;
-                    break;
-                case InformationBoxOpacity.Faded30:
-                    Opacity = 0.3;
-                    break;
-                case InformationBoxOpacity.Faded40:
-                    Opacity = 0.4;
-                    break;
-                case InformationBoxOpacity.Faded50:
-                    Opacity = 0.5;
-                    break;
-                case InformationBoxOpacity.Faded60:
-                    Opacity = 0.6;
-                    break;
-                case InformationBoxOpacity.Faded70:
-                    Opacity = 0.7;
-                    break;
-                case InformationBoxOpacity.Faded80:
-                    Opacity = 0.8;
-                    break;
-                case InformationBoxOpacity.Faded90:
-                    Opacity = 0.9;
-                    break;
-                case InformationBoxOpacity.NoFade:
-                    Opacity = 1.0;
-                    break;
-                default:
-                    break;
-            }
+            Opacity = this.viewModel.GetOpacityValue();
         }
 
         #endregion Opacity
@@ -872,53 +298,35 @@ namespace InfoBox
         #region Style
 
         /// <summary>
-        /// Sets the window style.
+        /// Applies the window style.
         /// </summary>
-        private void SetWindowStyle()
+        private void ApplyWindowStyle()
         {
-            if (this.style == InformationBoxStyle.Modern)
+            var config = this.viewModel.GetWindowStyleConfiguration();
+
+            this.pnlForm.BackColor = config.FormBackColor;
+            this.messageText.BackColor = config.FormBackColor;
+            this.pnlButtons.BackColor = config.BarsBackColor;
+            this.lblTitle.BackColor = config.BarsBackColor;
+
+            FormBorderStyle = config.BorderStyle;
+            this.lblTitle.Visible = config.TitleLabelVisible;
+
+            if (config.TitleLabelVisible)
             {
-                Color barsBackColor = Color.Black;
-                Color formBackColor = Color.Silver;
-
-                if (null != this.design)
-                {
-                    barsBackColor = this.design.BarsBackColor;
-                    formBackColor = this.design.FormBackColor;
-                }
-
-                this.pnlForm.BackColor = formBackColor;
-                this.messageText.BackColor = formBackColor;
-
-                this.pnlButtons.BackColor = barsBackColor;
-                this.lblTitle.BackColor = barsBackColor;
-
-                FormBorderStyle = FormBorderStyle.None;
-                this.lblTitle.Visible = true;
-
                 foreach (Controls.Button button in this.pnlButtons.Controls)
                 {
-                    button.BackColor = barsBackColor;
+                    button.BackColor = config.BarsBackColor;
                 }
             }
-            else if (this.style == InformationBoxStyle.Standard)
+
+            if (config.AdjustPanelTop)
             {
-                Color barsBackColor = SystemColors.Control;
-                Color formBackColor = SystemColors.Control;
-
-                if (null != this.design)
-                {
-                    barsBackColor = this.design.BarsBackColor;
-                    formBackColor = this.design.FormBackColor;
-                }
-
-                this.pnlButtons.BackColor = barsBackColor;
-                this.pnlForm.BackColor = formBackColor;
-                this.messageText.BackColor = formBackColor;
-
-                FormBorderStyle = FormBorderStyle.FixedDialog;
-                this.lblTitle.Visible = false;
                 this.pnlMain.Top -= this.lblTitle.Height;
+            }
+
+            if (config.RemoveSideBorder)
+            {
                 this.pnlButtons.SideBorder = SideBorder.None;
             }
         }
@@ -928,20 +336,16 @@ namespace InfoBox
         #region CheckBox
 
         /// <summary>
-        /// Sets the check box.
+        /// Applies the check box configuration.
         /// </summary>
-        private void SetCheckBox()
+        private void ApplyCheckBox()
         {
-            this.chbDoNotShow.Text = this.doNotShowAgainText ?? Resources.LabelDoNotShow;
-
-            this.chbDoNotShow.Visible = ((this.checkBox & InformationBoxCheckBox.Show) == InformationBoxCheckBox.Show);
-            this.chbDoNotShow.Checked = ((this.checkBox & InformationBoxCheckBox.Checked) == InformationBoxCheckBox.Checked);
-            this.chbDoNotShow.TextAlign = ((this.checkBox & InformationBoxCheckBox.RightAligned) == InformationBoxCheckBox.RightAligned)
-                                         ? ContentAlignment.BottomRight
-                                         : ContentAlignment.BottomLeft;
-            this.chbDoNotShow.CheckAlign = ((this.checkBox & InformationBoxCheckBox.RightAligned) == InformationBoxCheckBox.RightAligned)
-                                          ? ContentAlignment.MiddleRight
-                                          : ContentAlignment.MiddleLeft;
+            var config = this.viewModel.GetCheckBoxConfiguration();
+            this.chbDoNotShow.Text = config.Text;
+            this.chbDoNotShow.Visible = config.Visible;
+            this.chbDoNotShow.Checked = config.Checked;
+            this.chbDoNotShow.TextAlign = config.TextAlign;
+            this.chbDoNotShow.CheckAlign = config.CheckAlign;
         }
 
         #endregion CheckBox
@@ -949,11 +353,11 @@ namespace InfoBox
         #region Position
 
         /// <summary>
-        /// Sets the position.
+        /// Applies the position.
         /// </summary>
-        private void SetPosition()
+        private void ApplyPosition()
         {
-            if (this.position == InformationBoxPosition.CenterOnScreen)
+            if (this.viewModel.Position == InformationBoxPosition.CenterOnScreen)
             {
                 StartPosition = FormStartPosition.CenterScreen;
                 CenterToScreen();
@@ -977,21 +381,21 @@ namespace InfoBox
         #region Focus
 
         /// <summary>
-        /// Sets the focus.
+        /// Applies the focus.
         /// </summary>
-        private void SetFocus()
+        private void ApplyFocus()
         {
-            if (this.defaultButton == InformationBoxDefaultButton.Button1 && this.pnlButtons.Controls.Count > 0)
+            if (this.viewModel.DefaultButton == InformationBoxDefaultButton.Button1 && this.pnlButtons.Controls.Count > 0)
             {
                 this.pnlButtons.Controls[0].Select();
             }
 
-            if (this.defaultButton == InformationBoxDefaultButton.Button2 && this.pnlButtons.Controls.Count > 1)
+            if (this.viewModel.DefaultButton == InformationBoxDefaultButton.Button2 && this.pnlButtons.Controls.Count > 1)
             {
                 this.pnlButtons.Controls[1].Select();
             }
 
-            if (this.defaultButton == InformationBoxDefaultButton.Button3 && this.pnlButtons.Controls.Count > 2)
+            if (this.viewModel.DefaultButton == InformationBoxDefaultButton.Button3 && this.pnlButtons.Controls.Count > 2)
             {
                 this.pnlButtons.Controls[2].Select();
             }
@@ -1002,9 +406,9 @@ namespace InfoBox
         #region Layout
 
         /// <summary>
-        /// Sets the layout.
+        /// Applies the layout.
         /// </summary>
-        private void SetLayout()
+        private void ApplyLayout()
         {
             int totalHeight;
             int totalWidth;
@@ -1014,13 +418,13 @@ namespace InfoBox
 
             // Caption width including button
             int captionWidth = TextRenderer.MeasureText(Text, SystemFonts.CaptionFont, Size.Empty, TextFormatFlags.NoPadding | TextFormatFlags.NoPrefix).Width + ScaleDpi(30);
-            if (this.titleStyle != InformationBoxTitleIconStyle.None)
+            if (this.viewModel.TitleStyle != InformationBoxTitleIconStyle.None)
             {
                 captionWidth += ScaleDpi(BorderPadding) * 2;
             }
 
             // "Do not show this dialog again" width
-            int checkBoxWidth = ((this.checkBox & InformationBoxCheckBox.Show) == InformationBoxCheckBox.Show)
+            int checkBoxWidth = this.viewModel.HasCheckBox()
                                     ? TextRenderer.MeasureText(this.chbDoNotShow.Text, this.chbDoNotShow.Font, Size.Empty, TextFormatFlags.NoPadding).Width + ScaleDpi(BorderPadding) * 4
                                     : 0;
 
@@ -1035,7 +439,7 @@ namespace InfoBox
             }
 
             // Icon width
-            if (this.icon != InformationBoxIcon.None || this.iconType == IconType.UserDefined)
+            if (this.viewModel.HasIcon())
             {
                 iconAndTextWidth += ScaleDpi(IconPanelWidth);
             }
@@ -1050,13 +454,13 @@ namespace InfoBox
 
             #region Height
 
-            if ((this.checkBox & InformationBoxCheckBox.Show) != InformationBoxCheckBox.Show)
+            if (!this.viewModel.HasCheckBox())
             {
                 this.chbDoNotShow.Visible = false;
             }
 
             int iconHeight = 0;
-            if (this.icon != InformationBoxIcon.None || this.iconType == IconType.UserDefined)
+            if (this.viewModel.HasIcon())
             {
                 iconHeight = this.pcbIcon.Height;
             }
@@ -1083,7 +487,7 @@ namespace InfoBox
 
             this.pnlMain.Size = new Size(Math.Min(Screen.PrimaryScreen.WorkingArea.Width - ScaleDpi(20), totalWidth), totalHeight - this.pnlBas.Height);
 
-            if (this.style == InformationBoxStyle.Modern)
+            if (this.viewModel.Style == InformationBoxStyle.Modern)
             {
                 totalHeight += this.lblTitle.Height;
             }
@@ -1101,7 +505,7 @@ namespace InfoBox
             this.pcbIcon.Top = ScaleDpi(BorderPadding);
 
             // Text
-            this.pnlScrollText.Width = ClientSize.Width - ((this.icon != InformationBoxIcon.None || this.iconType == IconType.UserDefined)
+            this.pnlScrollText.Width = ClientSize.Width - (this.viewModel.HasIcon()
                                        ? ScaleDpi(IconPanelWidth) + ScaleDpi(BorderPadding) + ScaleDpi(5)
                                        : ScaleDpi(BorderPadding));
             this.messageText.Left = 0;
@@ -1118,22 +522,22 @@ namespace InfoBox
             }
 
             // Buttons
-            this.SetButtonsLayout();
+            this.ApplyButtonsLayout();
 
             #endregion Position
         }
 
         /// <summary>
-        /// Sets the buttons layout.
+        /// Applies the buttons layout.
         /// </summary>
-        private void SetButtonsLayout()
+        private void ApplyButtonsLayout()
         {
             // Do not count the checkbox
             int buttonsCount = this.pnlButtons.Controls.Count;
             int index = 0;
             int initialPosition = 0;
             int spaceBetween = 0;
-            switch (this.buttonsLayout)
+            switch (this.viewModel.ButtonsLayout)
             {
                 case InformationBoxButtonsLayout.GroupLeft:
                     spaceBetween = ScaleDpi(BorderPadding);
@@ -1177,50 +581,24 @@ namespace InfoBox
         #region Icon
 
         /// <summary>
-        /// Sets the icon.
+        /// Applies the icon configuration.
         /// </summary>
-        private void SetIcon()
+        private void ApplyIcon()
         {
-            if (this.iconType == IconType.Internal)
-            {
-                if (this.icon == InformationBoxIcon.None)
-                {
-                    this.pnlIcon.Visible = false;
-                    this.pcbIcon.Image = null;
-                }
-                else
-                {
-                    this.pnlIcon.Visible = true;
-                    this.pcbIcon.Image = IconHelper.FromEnum(this.icon).ToBitmap();
-                }
-            }
-            else
-            {
-                this.pcbIcon.Image = new Icon(this.customIcon, ScaleDpi(48), ScaleDpi(48)).ToBitmap();
-                this.pnlIcon.Visible = true;
-            }
+            var config = this.viewModel.GetIconConfiguration(ScaleDpi(48));
 
+            this.pnlIcon.Visible = config.IconPanelVisible;
+            this.pcbIcon.Image = config.IconImage;
             this.pnlIcon.Width = ScaleDpi(IconPanelWidth);
 
-            if (this.titleStyle == InformationBoxTitleIconStyle.None)
+            if (!config.ShowFormIcon)
             {
                 ShowIcon = false;
-                Icon = Resources.IconBlank;
             }
-            else if (this.titleStyle == InformationBoxTitleIconStyle.SameAsBox)
+
+            if (config.FormIcon != null)
             {
-                if (this.iconType == IconType.Internal)
-                {
-                    Icon = IconHelper.FromEnum(this.icon);
-                }
-                else
-                {
-                    Icon = this.customIcon;
-                }
-            }
-            else if (this.titleStyle == InformationBoxTitleIconStyle.Custom)
-            {
-                Icon = this.titleIcon;
+                Icon = config.FormIcon;
             }
         }
 
@@ -1229,11 +607,11 @@ namespace InfoBox
         #region Z-Order
 
         /// <summary>
-        /// Sets the order.
+        /// Applies the z-order.
         /// </summary>
-        private void SetOrder()
+        private void ApplyOrder()
         {
-            if (this.order == InformationBoxOrder.TopMost)
+            if (this.viewModel.Order == InformationBoxOrder.TopMost)
             {
                 this.TopMost = true;
             }
@@ -1244,20 +622,20 @@ namespace InfoBox
         #region Font
 
         /// <summary>
-        /// Sets the font.
+        /// Applies the font.
         /// </summary>
-        private void SetFont()
+        private void ApplyFont()
         {
-            if (this.fontParameters != null)
+            if (this.viewModel.FontParameters != null)
             {
-                if (this.fontParameters.HasFont())
+                if (this.viewModel.FontParameters.HasFont())
                 {
-                    this.messageText.Font = this.fontParameters.MessageFont;
+                    this.messageText.Font = this.viewModel.FontParameters.MessageFont;
                 }
 
-                if (this.fontParameters.HasColor())
+                if (this.viewModel.FontParameters.HasColor())
                 {
-                    this.messageText.ForeColor = this.fontParameters.MessageColor.Value;
+                    this.messageText.ForeColor = this.viewModel.FontParameters.MessageColor.Value;
                 }
             }
         }
@@ -1267,17 +645,17 @@ namespace InfoBox
         #region Text
 
         /// <summary>
-        /// Sets the text.
+        /// Applies the text layout.
         /// </summary>
-        private void SetText()
+        private void ApplyText()
         {
             Screen currentScreen = Screen.FromControl(this);
             int screenWidth = currentScreen.WorkingArea.Width;
 
             var internalText = String.Empty;
-            internalText = TextHelper.NormalizeLineBreaks(this.messageText.Text);                       
+            internalText = TextHelper.NormalizeLineBreaks(this.messageText.Text);
 
-            if (this.autoSizeMode == InformationBoxAutoSizeMode.FitToText)
+            if (this.viewModel.AutoSizeMode == InformationBoxAutoSizeMode.FitToText)
             {
                 this.messageText.WordWrap = false;
                 this.messageText.Text = internalText.ToString();
@@ -1285,7 +663,7 @@ namespace InfoBox
             }
             else
             {
-                if (this.autoSizeMode == InformationBoxAutoSizeMode.None)
+                if (this.viewModel.AutoSizeMode == InformationBoxAutoSizeMode.None)
                 {
                     this.messageText.WordWrap = true;
                     this.messageText.Text = internalText.ToString();
@@ -1293,7 +671,7 @@ namespace InfoBox
                 }
                 else
                 {
-                    if (this.autoSizeMode == InformationBoxAutoSizeMode.MinimumHeight)
+                    if (this.viewModel.AutoSizeMode == InformationBoxAutoSizeMode.MinimumHeight)
                     {
                         // Remove line breaks.
                         internalText = TextHelper.ReplaceLineBreaksWithSpaces(internalText);
@@ -1317,7 +695,7 @@ namespace InfoBox
 
                         internalText = formattedText.ToString();
                     }
-                    else if (this.autoSizeMode == InformationBoxAutoSizeMode.MinimumWidth)
+                    else if (this.viewModel.AutoSizeMode == InformationBoxAutoSizeMode.MinimumWidth)
                     {
                         internalText = TextHelper.AddLineBreaksAfterPunctuation(internalText);
                     }
@@ -1335,98 +713,23 @@ namespace InfoBox
         #region Buttons
 
         /// <summary>
-        /// Sets the buttons, order of addition is respected.
+        /// Applies the buttons from the viewmodel definitions.
         /// </summary>
-        private void SetButtons()
+        private void ApplyButtons()
         {
-            // Abort button
-            if (this.buttons == InformationBoxButtons.AbortRetryIgnore)
+            var definitions = this.viewModel.GetButtonDefinitions();
+            foreach (var def in definitions)
             {
-                this.AddButton("Abort", Resources.LabelAbort);
+                this.AddButton(def.Name, def.Text);
             }
 
-            // Ok
-            if (this.buttons == InformationBoxButtons.OK ||
-                this.buttons == InformationBoxButtons.OKCancel ||
-                this.buttons == InformationBoxButtons.OKCancelUser1)
-            {
-                this.AddButton("OK", Resources.LabelOK);
-            }
-
-            // Yes
-            if (this.buttons == InformationBoxButtons.YesNo ||
-                this.buttons == InformationBoxButtons.YesNoCancel ||
-                this.buttons == InformationBoxButtons.YesNoUser1)
-            {
-                this.AddButton("Yes", Resources.LabelYes);
-            }
-
-            // Retry
-            if (this.buttons == InformationBoxButtons.AbortRetryIgnore ||
-                this.buttons == InformationBoxButtons.RetryCancel)
-            {
-                this.AddButton("Retry", Resources.LabelRetry);
-            }
-
-            // No
-            if (this.buttons == InformationBoxButtons.YesNo ||
-                this.buttons == InformationBoxButtons.YesNoCancel ||
-                this.buttons == InformationBoxButtons.YesNoUser1)
-            {
-                this.AddButton("No", Resources.LabelNo);
-            }
-
-            // Cancel
-            if (this.buttons == InformationBoxButtons.OKCancel ||
-                this.buttons == InformationBoxButtons.OKCancelUser1 ||
-                this.buttons == InformationBoxButtons.RetryCancel ||
-                this.buttons == InformationBoxButtons.YesNoCancel)
-            {
-                this.AddButton("Cancel", Resources.LabelCancel);
-            }
-
-            // Ignore
-            if (this.buttons == InformationBoxButtons.AbortRetryIgnore)
-            {
-                this.AddButton("Ignore", Resources.LabelIgnore);
-            }
-
-            // User1
-            if (this.buttons == InformationBoxButtons.OKCancelUser1 ||
-                this.buttons == InformationBoxButtons.User1User2User3 ||
-                this.buttons == InformationBoxButtons.User1User2 ||
-                this.buttons == InformationBoxButtons.YesNoUser1 ||
-                this.buttons == InformationBoxButtons.User1)
-            {
-                this.AddButton("User1", this.buttonUser1Text);
-            }
-
-            // User2
-            if (this.buttons == InformationBoxButtons.User1User2 ||
-                this.buttons == InformationBoxButtons.User1User2User3)
-            {
-                this.AddButton("User2", this.buttonUser2Text);
-            }
-
-            // User3
-            if (this.buttons == InformationBoxButtons.User1User2User3)
-            {
-                this.AddButton("User3", this.buttonUser3Text);
-            }
-
-            // Help button is displayed when asked or when a help file name exists
-            if (this.showHelpButton || !String.IsNullOrEmpty(this.helpFile))
-            {
-                this.AddButton("Help", Resources.LabelHelp);
-            }
-
-            this.SetButtonsSize();
+            this.ApplyButtonsSize();
         }
 
         /// <summary>
-        /// Sets the buttons size.
+        /// Applies the buttons size.
         /// </summary>
-        private void SetButtonsSize()
+        private void ApplyButtonsSize()
         {
             // All button will have the same size
             int maxSize = 0;
@@ -1439,12 +742,12 @@ namespace InfoBox
 
             foreach (Control ctrl in this.pnlButtons.Controls)
             {
-                if (this.style == InformationBoxStyle.Standard)
+                if (this.viewModel.Style == InformationBoxStyle.Standard)
                 {
                     ctrl.Size = new Size(maxSize, ScaleDpi(23));
                     ctrl.Top = ScaleDpi(5);
                 }
-                else if (this.style == InformationBoxStyle.Modern)
+                else if (this.viewModel.Style == InformationBoxStyle.Modern)
                 {
                     ctrl.Size = new Size(maxSize, this.pnlButtons.Height);
                     ctrl.Top = 0;
@@ -1461,7 +764,7 @@ namespace InfoBox
         {
             Control buttonToAdd;
 
-            if (this.style == InformationBoxStyle.Modern)
+            if (this.viewModel.Style == InformationBoxStyle.Modern)
             {
                 buttonToAdd = new Controls.Button();
                 (buttonToAdd as Controls.Button).PersistantMode = false;
@@ -1494,51 +797,16 @@ namespace InfoBox
         private void HandleButton(Control sender)
         {
             Control senderControl = sender;
-            switch (senderControl.Name)
-            {
-                case "Abort":
-                    this.result = InformationBoxResult.Abort;
-                    break;
-                case "OK":
-                    this.result = InformationBoxResult.OK;
-                    break;
-                case "Yes":
-                    this.result = InformationBoxResult.Yes;
-                    break;
-                case "Retry":
-                    this.result = InformationBoxResult.Retry;
-                    break;
-                case "No":
-                    this.result = InformationBoxResult.No;
-                    break;
-                case "Cancel":
-                    this.result = InformationBoxResult.Cancel;
-                    break;
-                case "Ignore":
-                    this.result = InformationBoxResult.Ignore;
-                    break;
-                case "User1":
-                    this.result = InformationBoxResult.User1;
-                    break;
-                case "User2":
-                    this.result = InformationBoxResult.User2;
-                    break;
-                case "User3":
-                    this.result = InformationBoxResult.User3;
-                    break;
-                default:
-                    this.result = InformationBoxResult.None;
-                    break;
-            }
 
-            if (senderControl.Name.Equals("Help"))
+            if (this.viewModel.IsHelpButton(senderControl.Name))
             {
                 this.OpenHelp();
             }
             else
             {
+                this.result = this.viewModel.MapButtonNameToResult(senderControl.Name);
                 DialogResult = DialogResult.OK;
-                if (this.behavior == InformationBoxBehavior.Modeless)
+                if (this.viewModel.Behavior == InformationBoxBehavior.Modeless)
                 {
                     Close();
                 }
@@ -1566,16 +834,16 @@ namespace InfoBox
             }
 
             // If a help file is specified
-            if (!String.IsNullOrEmpty(this.helpFile))
+            if (!String.IsNullOrEmpty(this.viewModel.HelpFile))
             {
                 // If no topic is specified
-                if (String.IsNullOrEmpty(this.helpTopic))
+                if (String.IsNullOrEmpty(this.viewModel.HelpTopic))
                 {
-                    Help.ShowHelp(this.activeForm, this.helpFile, this.helpNavigator);
+                    Help.ShowHelp(this.activeForm, this.viewModel.HelpFile, this.viewModel.HelpNavigator);
                 }
                 else
                 {
-                    Help.ShowHelp(this.activeForm, this.helpFile, this.helpTopic);
+                    Help.ShowHelp(this.activeForm, this.viewModel.HelpFile, this.viewModel.HelpTopic);
                 }
             }
         }
@@ -1592,10 +860,10 @@ namespace InfoBox
             base.OnDpiChanged(e);
             this.dpiScale = e.DeviceDpiNew / 96f;
             this.pnlScrollText.AutoScrollPosition = Point.Empty;
-            this.SetButtonsSize();
-            this.SetText();
-            this.SetIcon();
-            this.SetLayout();
+            this.ApplyButtonsSize();
+            this.ApplyText();
+            this.ApplyIcon();
+            this.ApplyLayout();
         }
 
         /// <summary>
@@ -1623,9 +891,9 @@ namespace InfoBox
                 this.result = InformationBoxResult.Cancel;
             }
 
-            if (this.behavior == InformationBoxBehavior.Modeless && null != this.callback)
+            if (this.viewModel.Behavior == InformationBoxBehavior.Modeless && null != this.viewModel.Callback)
             {
-                Invoke(this.callback, this.result);
+                Invoke(this.viewModel.Callback, this.result);
             }
         }
 
@@ -1636,7 +904,7 @@ namespace InfoBox
         /// <param name="e">The <see cref="System.Windows.Forms.PaintEventArgs"/> instance containing the event data.</param>
         private void PnlForm_Paint(object sender, PaintEventArgs e)
         {
-            if (this.style == InformationBoxStyle.Modern)
+            if (this.viewModel.Style == InformationBoxStyle.Modern)
             {
                 ControlPaint.DrawBorder(e.Graphics, this.pnlForm.ClientRectangle, Color.Black, ButtonBorderStyle.Solid);
             }
@@ -1708,113 +976,34 @@ namespace InfoBox
         /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
         private void TmrAutoClose_Tick(object sender, EventArgs e)
         {
-            if (this.elapsedTime == this.autoClose.Seconds)
+            var tickResult = this.viewModel.ProcessAutoCloseTick(this.elapsedTime, this.pnlButtons.Controls.Count);
+
+            if (tickResult.ShouldStopTimer)
             {
                 this.tmrAutoClose.Stop();
-
-                switch (this.autoClose.Mode)
-                {
-                    case AutoCloseDefinedParameters.Button:
-                        if (this.autoClose.DefaultButton == InformationBoxDefaultButton.Button1 && this.pnlButtons.Controls.Count > 0)
-                        {
-                            this.HandleButton(this.pnlButtons.Controls[0]);
-                        }
-                        else if (this.autoClose.DefaultButton == InformationBoxDefaultButton.Button2 && this.pnlButtons.Controls.Count > 1)
-                        {
-                            this.HandleButton(this.pnlButtons.Controls[1]);
-                        }
-                        else if (this.autoClose.DefaultButton == InformationBoxDefaultButton.Button3 && this.pnlButtons.Controls.Count > 2)
-                        {
-                            this.HandleButton(this.pnlButtons.Controls[2]);
-                        }
-
-                        return;
-                    case AutoCloseDefinedParameters.TimeOnly:
-                        if (this.defaultButton == InformationBoxDefaultButton.Button1 && this.pnlButtons.Controls.Count > 0)
-                        {
-                            this.HandleButton(this.pnlButtons.Controls[0]);
-                        }
-                        else if (this.defaultButton == InformationBoxDefaultButton.Button2 && this.pnlButtons.Controls.Count > 1)
-                        {
-                            this.HandleButton(this.pnlButtons.Controls[1]);
-                        }
-                        else if (this.defaultButton == InformationBoxDefaultButton.Button3 && this.pnlButtons.Controls.Count > 2)
-                        {
-                            this.HandleButton(this.pnlButtons.Controls[2]);
-                        }
-
-                        return;
-                    case AutoCloseDefinedParameters.Result:
-                        this.result = this.autoClose.Result;
-                        DialogResult = DialogResult.OK;
-                        return;
-                    default:
-                        break;
-                }
             }
-            else
+
+            if (tickResult.ShouldClose)
             {
-                Control buttonToUpdate = null;
-                if (this.autoClose.Mode == AutoCloseDefinedParameters.Button)
+                if (tickResult.UseDirectResult)
                 {
-                    if (this.autoClose.DefaultButton == InformationBoxDefaultButton.Button1 && this.pnlButtons.Controls.Count > 0)
-                    {
-                        buttonToUpdate = this.pnlButtons.Controls[0];
-                    }
-                    else if (this.autoClose.DefaultButton == InformationBoxDefaultButton.Button2 && this.pnlButtons.Controls.Count > 1)
-                    {
-                        buttonToUpdate = this.pnlButtons.Controls[1];
-                    }
-                    else if (this.autoClose.DefaultButton == InformationBoxDefaultButton.Button3 && this.pnlButtons.Controls.Count > 2)
-                    {
-                        buttonToUpdate = this.pnlButtons.Controls[2];
-                    }
+                    this.result = tickResult.DirectResult;
+                    DialogResult = DialogResult.OK;
                 }
-                else
+                else if (tickResult.ButtonIndex >= 0)
                 {
-                    if (this.defaultButton == InformationBoxDefaultButton.Button1 && this.pnlButtons.Controls.Count > 0)
-                    {
-                        buttonToUpdate = this.pnlButtons.Controls[0];
-                    }
-                    else if (this.defaultButton == InformationBoxDefaultButton.Button2 && this.pnlButtons.Controls.Count > 1)
-                    {
-                        buttonToUpdate = this.pnlButtons.Controls[1];
-                    }
-                    else if (this.defaultButton == InformationBoxDefaultButton.Button3 && this.pnlButtons.Controls.Count > 2)
-                    {
-                        buttonToUpdate = this.pnlButtons.Controls[2];
-                    }
+                    this.HandleButton(this.pnlButtons.Controls[tickResult.ButtonIndex]);
                 }
 
-                if (null != buttonToUpdate)
-                {
-                    Regex extractLabel = new Regex(@".*?\(\d+\)");
+                return;
+            }
 
-                    if (buttonToUpdate is System.Windows.Forms.Button)
-                    {
-                        System.Windows.Forms.Button button = (System.Windows.Forms.Button)buttonToUpdate;
-                        if (extractLabel.IsMatch(button.Text))
-                        {
-                            button.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", button.Text.Substring(0, button.Text.LastIndexOf(" (", StringComparison.OrdinalIgnoreCase)), this.autoClose.Seconds - this.elapsedTime);
-                        }
-                        else
-                        {
-                            button.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", button.Text, this.autoClose.Seconds - this.elapsedTime);
-                        }
-                    }
-                    else if (buttonToUpdate is Controls.Button)
-                    {
-                        Controls.Button button = (Controls.Button)buttonToUpdate;
-                        if (extractLabel.IsMatch(button.Text))
-                        {
-                            button.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", button.Text.Substring(0, button.Text.LastIndexOf(" (", StringComparison.OrdinalIgnoreCase)), this.autoClose.Seconds - this.elapsedTime);
-                        }
-                        else
-                        {
-                            button.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", button.Text, this.autoClose.Seconds - this.elapsedTime);
-                        }
-                    }
-                }
+            // Update button text with countdown
+            if (tickResult.ButtonIndex >= 0)
+            {
+                Control buttonToUpdate = this.pnlButtons.Controls[tickResult.ButtonIndex];
+                int secondsRemaining = this.viewModel.GetAutoCloseSecondsRemaining(this.elapsedTime);
+                buttonToUpdate.Text = this.viewModel.FormatAutoCloseButtonText(buttonToUpdate.Text, secondsRemaining);
             }
 
             this.elapsedTime++;

--- a/InfoBox/InfoBox.csproj
+++ b/InfoBox/InfoBox.csproj
@@ -159,8 +159,15 @@
     <Compile Include="InformationBox.cs" />
     <Compile Include="Enums\AutoCloseDefinedParameters.cs" />
     <Compile Include="Internals\IconHelper.cs" />
+    <Compile Include="Internals\InformationBoxViewModel.cs" />
+    <Compile Include="Internals\IScreenProvider.cs" />
+    <Compile Include="Internals\ITextMeasurer.cs" />
     <Compile Include="Internals\MessageBoxEnumConverter.cs" />
+    <Compile Include="Internals\ParameterParser.cs" />
     <Compile Include="Internals\TextHelper.cs" />
+    <Compile Include="Internals\ViewModelTypes.cs" />
+    <Compile Include="Internals\WinFormsScreenProvider.cs" />
+    <Compile Include="Internals\WinFormsTextMeasurer.cs" />
     <Compile Include="Parameters\AutoCloseParameters.cs" />
     <Compile Include="Parameters\DesignParameters.cs" />
     <Compile Include="Parameters\FontParameters.cs" />

--- a/InfoBox/InformationBox.cs
+++ b/InfoBox/InformationBox.cs
@@ -6,6 +6,7 @@
 
 namespace InfoBox
 {
+    using InfoBox.Internals;
     using System.Drawing;
     using System.Windows.Forms;
 
@@ -206,9 +207,10 @@ namespace InfoBox
                                                 InformationBoxOrder order = InformationBoxOrder.Default,
                                                 InformationBoxSound sound = InformationBoxSound.Default)
         {
-            return new InformationBoxForm(text, title, helpFile, helpTopic, initialization, buttons, icon, customIcon, defaultButton,
+            var vm = ParameterParser.ParseNamed(text, title, helpFile, helpTopic, initialization, buttons, icon, customIcon, defaultButton,
                  customButtons, buttonsLayout, autoSizeMode, position, showHelpButton, helpNavigator, showDoNotShowAgainCheckBox, doNotShowAgainText,
-                 style, autoClose, design, fontParameters, font, titleStyle, titleIcon, legacyButtons, legacyIcon, legacyDefaultButton, behavior, callback, opacity, parent, order, sound).Show();
+                 style, autoClose, design, fontParameters, font, titleStyle, titleIcon, legacyButtons, legacyIcon, legacyDefaultButton, behavior, callback, opacity, parent, order, sound);
+            return new InformationBoxForm(vm).Show();
         }
 
         /// <summary>
@@ -417,9 +419,10 @@ namespace InfoBox
                                                 InformationBoxOrder order = InformationBoxOrder.Default,
                                                 InformationBoxSound sound = InformationBoxSound.Default)
         {
-            return new InformationBoxForm(text, title, helpFile, helpTopic, initialization, buttons, icon, customIcon, defaultButton,
+            var vm = ParameterParser.ParseNamed(text, title, helpFile, helpTopic, initialization, buttons, icon, customIcon, defaultButton,
                  customButtons, buttonsLayout, autoSizeMode, position, showHelpButton, helpNavigator, showDoNotShowAgainCheckBox, doNotShowAgainText,
-                 style, autoClose, design, fontParameters, font, titleStyle, titleIcon, legacyButtons, legacyIcon, legacyDefaultButton, behavior, callback, opacity, parent, order, sound).Show(out checkBoxState);
+                 style, autoClose, design, fontParameters, font, titleStyle, titleIcon, legacyButtons, legacyIcon, legacyDefaultButton, behavior, callback, opacity, parent, order, sound);
+            return new InformationBoxForm(vm).Show(out checkBoxState);
         }
 
         #endregion Show

--- a/InfoBox/Internals/IScreenProvider.cs
+++ b/InfoBox/Internals/IScreenProvider.cs
@@ -1,0 +1,9 @@
+namespace InfoBox.Internals
+{
+    using System.Drawing;
+
+    internal interface IScreenProvider
+    {
+        Rectangle WorkingArea { get; }
+    }
+}

--- a/InfoBox/Internals/ITextMeasurer.cs
+++ b/InfoBox/Internals/ITextMeasurer.cs
@@ -1,0 +1,10 @@
+namespace InfoBox.Internals
+{
+    using System.Drawing;
+    using System.Windows.Forms;
+
+    internal interface ITextMeasurer
+    {
+        Size MeasureText(string text, Font font, Size proposedSize, TextFormatFlags flags);
+    }
+}

--- a/InfoBox/Internals/InformationBoxViewModel.cs
+++ b/InfoBox/Internals/InformationBoxViewModel.cs
@@ -1,0 +1,550 @@
+namespace InfoBox.Internals
+{
+    using InfoBox.Properties;
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Globalization;
+    using System.Media;
+    using System.Text.RegularExpressions;
+    using System.Windows.Forms;
+
+    internal class InformationBoxViewModel
+    {
+        #region Properties
+
+        public string Text { get; set; } = string.Empty;
+
+        public string Title { get; set; } = string.Empty;
+
+        public string HelpFile { get; set; } = string.Empty;
+
+        public string HelpTopic { get; set; } = string.Empty;
+
+        public string ButtonUser1Text { get; set; } = "User1";
+
+        public string ButtonUser2Text { get; set; } = "User2";
+
+        public string ButtonUser3Text { get; set; } = "User3";
+
+        public string DoNotShowAgainText { get; set; }
+
+        public InformationBoxButtons Buttons { get; set; } = InformationBoxButtons.OK;
+
+        public InformationBoxIcon Icon { get; set; } = InformationBoxIcon.None;
+
+        public Icon CustomIcon { get; set; }
+
+        public IconType IconType { get; set; } = IconType.Internal;
+
+        public InformationBoxDefaultButton DefaultButton { get; set; } = InformationBoxDefaultButton.Button1;
+
+        public InformationBoxButtonsLayout ButtonsLayout { get; set; } = InformationBoxButtonsLayout.GroupMiddle;
+
+        public InformationBoxAutoSizeMode AutoSizeMode { get; set; } = InformationBoxAutoSizeMode.None;
+
+        public InformationBoxPosition Position { get; set; } = InformationBoxPosition.CenterOnParent;
+
+        public InformationBoxCheckBox CheckBox { get; set; } = 0;
+
+        public InformationBoxStyle Style { get; set; } = InformationBoxStyle.Standard;
+
+        public AutoCloseParameters AutoClose { get; set; }
+
+        public DesignParameters Design { get; set; }
+
+        public FontParameters FontParameters { get; set; }
+
+        public InformationBoxTitleIconStyle TitleStyle { get; set; } = InformationBoxTitleIconStyle.None;
+
+        public Icon TitleIcon { get; set; }
+
+        public InformationBoxBehavior Behavior { get; set; } = InformationBoxBehavior.Modal;
+
+        public AsyncResultCallback Callback { get; set; }
+
+        public InformationBoxOpacity Opacity { get; set; } = InformationBoxOpacity.NoFade;
+
+        public InformationBoxOrder Order { get; set; } = InformationBoxOrder.Default;
+
+        public InformationBoxSound Sound { get; set; } = InformationBoxSound.Default;
+
+        public bool ShowHelpButton { get; set; }
+
+        public HelpNavigator HelpNavigator { get; set; } = HelpNavigator.TableOfContents;
+
+        public Form Parent { get; set; }
+
+        #endregion Properties
+
+        #region Scope Loading
+
+        public void LoadFromScope()
+        {
+            if (InformationBoxScope.Current == null)
+            {
+                return;
+            }
+
+            InformationBoxScopeParameters parameters = InformationBoxScope.Current.Parameters;
+
+            if (parameters.Icon.HasValue)
+            {
+                this.Icon = parameters.Icon.Value;
+            }
+
+            if (parameters.CustomIcon != null)
+            {
+                this.IconType = IconType.UserDefined;
+                this.CustomIcon = parameters.CustomIcon;
+            }
+
+            if (parameters.Buttons.HasValue)
+            {
+                this.Buttons = parameters.Buttons.Value;
+            }
+
+            if (parameters.DefaultButton.HasValue)
+            {
+                this.DefaultButton = parameters.DefaultButton.Value;
+            }
+
+            if (parameters.Layout.HasValue)
+            {
+                this.ButtonsLayout = parameters.Layout.Value;
+            }
+
+            if (parameters.AutoSizeMode.HasValue)
+            {
+                this.AutoSizeMode = parameters.AutoSizeMode.Value;
+            }
+
+            if (parameters.Position.HasValue)
+            {
+                this.Position = parameters.Position.Value;
+            }
+
+            if (parameters.CheckBox.HasValue)
+            {
+                this.CheckBox = parameters.CheckBox.Value;
+            }
+
+            if (parameters.Style.HasValue)
+            {
+                this.Style = parameters.Style.Value;
+            }
+
+            if (parameters.AutoClose != null)
+            {
+                this.AutoClose = parameters.AutoClose;
+            }
+
+            if (parameters.Design != null)
+            {
+                this.Design = parameters.Design;
+            }
+
+            if (parameters.Font != null)
+            {
+                this.FontParameters = parameters.Font;
+            }
+
+            if (parameters.TitleIconStyle.HasValue)
+            {
+                this.TitleStyle = parameters.TitleIconStyle.Value;
+            }
+
+            if (parameters.TitleIcon != null)
+            {
+                this.TitleIcon = parameters.TitleIcon;
+            }
+
+            if (parameters.Behavior.HasValue)
+            {
+                this.Behavior = parameters.Behavior.Value;
+            }
+
+            if (parameters.Opacity.HasValue)
+            {
+                this.Opacity = parameters.Opacity.Value;
+            }
+
+            if (parameters.Help.HasValue)
+            {
+                this.ShowHelpButton = parameters.Help.Value;
+            }
+
+            if (parameters.HelpNavigator.HasValue)
+            {
+                this.HelpNavigator = parameters.HelpNavigator.Value;
+            }
+
+            if (parameters.Order.HasValue)
+            {
+                this.Order = parameters.Order.Value;
+            }
+
+            if (parameters.Sound.HasValue)
+            {
+                this.Sound = parameters.Sound.Value;
+            }
+        }
+
+        #endregion Scope Loading
+
+        #region Business Logic
+
+        public ButtonDefinition[] GetButtonDefinitions()
+        {
+            var list = new List<ButtonDefinition>();
+
+            if (this.Buttons == InformationBoxButtons.AbortRetryIgnore)
+            {
+                list.Add(new ButtonDefinition { Name = "Abort", Text = Resources.LabelAbort });
+            }
+
+            if (this.Buttons == InformationBoxButtons.OK ||
+                this.Buttons == InformationBoxButtons.OKCancel ||
+                this.Buttons == InformationBoxButtons.OKCancelUser1)
+            {
+                list.Add(new ButtonDefinition { Name = "OK", Text = Resources.LabelOK });
+            }
+
+            if (this.Buttons == InformationBoxButtons.YesNo ||
+                this.Buttons == InformationBoxButtons.YesNoCancel ||
+                this.Buttons == InformationBoxButtons.YesNoUser1)
+            {
+                list.Add(new ButtonDefinition { Name = "Yes", Text = Resources.LabelYes });
+            }
+
+            if (this.Buttons == InformationBoxButtons.AbortRetryIgnore ||
+                this.Buttons == InformationBoxButtons.RetryCancel)
+            {
+                list.Add(new ButtonDefinition { Name = "Retry", Text = Resources.LabelRetry });
+            }
+
+            if (this.Buttons == InformationBoxButtons.YesNo ||
+                this.Buttons == InformationBoxButtons.YesNoCancel ||
+                this.Buttons == InformationBoxButtons.YesNoUser1)
+            {
+                list.Add(new ButtonDefinition { Name = "No", Text = Resources.LabelNo });
+            }
+
+            if (this.Buttons == InformationBoxButtons.OKCancel ||
+                this.Buttons == InformationBoxButtons.OKCancelUser1 ||
+                this.Buttons == InformationBoxButtons.RetryCancel ||
+                this.Buttons == InformationBoxButtons.YesNoCancel)
+            {
+                list.Add(new ButtonDefinition { Name = "Cancel", Text = Resources.LabelCancel });
+            }
+
+            if (this.Buttons == InformationBoxButtons.AbortRetryIgnore)
+            {
+                list.Add(new ButtonDefinition { Name = "Ignore", Text = Resources.LabelIgnore });
+            }
+
+            if (this.Buttons == InformationBoxButtons.OKCancelUser1 ||
+                this.Buttons == InformationBoxButtons.User1User2User3 ||
+                this.Buttons == InformationBoxButtons.User1User2 ||
+                this.Buttons == InformationBoxButtons.YesNoUser1 ||
+                this.Buttons == InformationBoxButtons.User1)
+            {
+                list.Add(new ButtonDefinition { Name = "User1", Text = this.ButtonUser1Text });
+            }
+
+            if (this.Buttons == InformationBoxButtons.User1User2 ||
+                this.Buttons == InformationBoxButtons.User1User2User3)
+            {
+                list.Add(new ButtonDefinition { Name = "User2", Text = this.ButtonUser2Text });
+            }
+
+            if (this.Buttons == InformationBoxButtons.User1User2User3)
+            {
+                list.Add(new ButtonDefinition { Name = "User3", Text = this.ButtonUser3Text });
+            }
+
+            if (this.ShowHelpButton || !String.IsNullOrEmpty(this.HelpFile))
+            {
+                list.Add(new ButtonDefinition { Name = "Help", Text = Resources.LabelHelp });
+            }
+
+            return list.ToArray();
+        }
+
+        public InformationBoxResult MapButtonNameToResult(string buttonName)
+        {
+            switch (buttonName)
+            {
+                case "Abort": return InformationBoxResult.Abort;
+                case "OK": return InformationBoxResult.OK;
+                case "Yes": return InformationBoxResult.Yes;
+                case "Retry": return InformationBoxResult.Retry;
+                case "No": return InformationBoxResult.No;
+                case "Cancel": return InformationBoxResult.Cancel;
+                case "Ignore": return InformationBoxResult.Ignore;
+                case "User1": return InformationBoxResult.User1;
+                case "User2": return InformationBoxResult.User2;
+                case "User3": return InformationBoxResult.User3;
+                default: return InformationBoxResult.None;
+            }
+        }
+
+        public bool IsHelpButton(string buttonName)
+        {
+            return "Help".Equals(buttonName, StringComparison.Ordinal);
+        }
+
+        public double GetOpacityValue()
+        {
+            switch (this.Opacity)
+            {
+                case InformationBoxOpacity.Faded10: return 0.1;
+                case InformationBoxOpacity.Faded20: return 0.2;
+                case InformationBoxOpacity.Faded30: return 0.3;
+                case InformationBoxOpacity.Faded40: return 0.4;
+                case InformationBoxOpacity.Faded50: return 0.5;
+                case InformationBoxOpacity.Faded60: return 0.6;
+                case InformationBoxOpacity.Faded70: return 0.7;
+                case InformationBoxOpacity.Faded80: return 0.8;
+                case InformationBoxOpacity.Faded90: return 0.9;
+                case InformationBoxOpacity.NoFade: return 1.0;
+                default: return 1.0;
+            }
+        }
+
+        public SystemSound GetSystemSound()
+        {
+            if (this.Sound == InformationBoxSound.None)
+            {
+                return null;
+            }
+
+            if (this.IconType == IconType.UserDefined)
+            {
+                return SystemSounds.Beep;
+            }
+
+            switch (IconHelper.GetCategory(this.Icon))
+            {
+                case InformationBoxMessageCategory.Asterisk: return SystemSounds.Asterisk;
+                case InformationBoxMessageCategory.Exclamation: return SystemSounds.Exclamation;
+                case InformationBoxMessageCategory.Hand: return SystemSounds.Hand;
+                case InformationBoxMessageCategory.Question: return SystemSounds.Question;
+                default: return SystemSounds.Beep;
+            }
+        }
+
+        public CheckBoxConfiguration GetCheckBoxConfiguration()
+        {
+            bool isRightAligned = (this.CheckBox & InformationBoxCheckBox.RightAligned) == InformationBoxCheckBox.RightAligned;
+
+            return new CheckBoxConfiguration
+            {
+                Text = this.DoNotShowAgainText ?? Resources.LabelDoNotShow,
+                Visible = (this.CheckBox & InformationBoxCheckBox.Show) == InformationBoxCheckBox.Show,
+                Checked = (this.CheckBox & InformationBoxCheckBox.Checked) == InformationBoxCheckBox.Checked,
+                TextAlign = isRightAligned ? ContentAlignment.BottomRight : ContentAlignment.BottomLeft,
+                CheckAlign = isRightAligned ? ContentAlignment.MiddleRight : ContentAlignment.MiddleLeft,
+            };
+        }
+
+        public WindowStyleConfiguration GetWindowStyleConfiguration()
+        {
+            if (this.Style == InformationBoxStyle.Modern)
+            {
+                Color barsBackColor = Color.Black;
+                Color formBackColor = Color.Silver;
+
+                if (this.Design != null)
+                {
+                    barsBackColor = this.Design.BarsBackColor;
+                    formBackColor = this.Design.FormBackColor;
+                }
+
+                return new WindowStyleConfiguration
+                {
+                    BarsBackColor = barsBackColor,
+                    FormBackColor = formBackColor,
+                    BorderStyle = FormBorderStyle.None,
+                    TitleLabelVisible = true,
+                    AdjustPanelTop = false,
+                    RemoveSideBorder = false,
+                };
+            }
+            else
+            {
+                Color barsBackColor = SystemColors.Control;
+                Color formBackColor = SystemColors.Control;
+
+                if (this.Design != null)
+                {
+                    barsBackColor = this.Design.BarsBackColor;
+                    formBackColor = this.Design.FormBackColor;
+                }
+
+                return new WindowStyleConfiguration
+                {
+                    BarsBackColor = barsBackColor,
+                    FormBackColor = formBackColor,
+                    BorderStyle = FormBorderStyle.FixedDialog,
+                    TitleLabelVisible = false,
+                    AdjustPanelTop = true,
+                    RemoveSideBorder = true,
+                };
+            }
+        }
+
+        public IconConfiguration GetIconConfiguration(int scaledIconSize)
+        {
+            var config = new IconConfiguration();
+
+            if (this.IconType == IconType.Internal)
+            {
+                if (this.Icon == InformationBoxIcon.None)
+                {
+                    config.IconPanelVisible = false;
+                    config.IconImage = null;
+                }
+                else
+                {
+                    config.IconPanelVisible = true;
+                    config.IconImage = IconHelper.FromEnum(this.Icon).ToBitmap();
+                }
+            }
+            else
+            {
+                config.IconImage = new Icon(this.CustomIcon, scaledIconSize, scaledIconSize).ToBitmap();
+                config.IconPanelVisible = true;
+            }
+
+            if (this.TitleStyle == InformationBoxTitleIconStyle.None)
+            {
+                config.ShowFormIcon = false;
+                config.FormIcon = Resources.IconBlank;
+            }
+            else if (this.TitleStyle == InformationBoxTitleIconStyle.SameAsBox)
+            {
+                config.ShowFormIcon = true;
+                config.FormIcon = this.IconType == IconType.Internal
+                    ? IconHelper.FromEnum(this.Icon)
+                    : this.CustomIcon;
+            }
+            else if (this.TitleStyle == InformationBoxTitleIconStyle.Custom)
+            {
+                config.ShowFormIcon = true;
+                config.FormIcon = this.TitleIcon;
+            }
+
+            return config;
+        }
+
+        public bool HasIcon()
+        {
+            return this.Icon != InformationBoxIcon.None || this.IconType == IconType.UserDefined;
+        }
+
+        public bool HasCheckBox()
+        {
+            return (this.CheckBox & InformationBoxCheckBox.Show) == InformationBoxCheckBox.Show;
+        }
+
+        public int GetAutoCloseButtonIndex(int buttonCount)
+        {
+            if (this.AutoClose == null)
+            {
+                return -1;
+            }
+
+            InformationBoxDefaultButton button;
+            if (this.AutoClose.Mode == AutoCloseDefinedParameters.Button)
+            {
+                button = this.AutoClose.DefaultButton;
+            }
+            else
+            {
+                button = this.DefaultButton;
+            }
+
+            if (button == InformationBoxDefaultButton.Button1 && buttonCount > 0)
+            {
+                return 0;
+            }
+            else if (button == InformationBoxDefaultButton.Button2 && buttonCount > 1)
+            {
+                return 1;
+            }
+            else if (button == InformationBoxDefaultButton.Button3 && buttonCount > 2)
+            {
+                return 2;
+            }
+
+            return -1;
+        }
+
+        public AutoCloseTickResult ProcessAutoCloseTick(int elapsedTime, int buttonCount)
+        {
+            var result = new AutoCloseTickResult { ButtonIndex = -1 };
+
+            if (this.AutoClose == null)
+            {
+                return result;
+            }
+
+            if (elapsedTime == this.AutoClose.Seconds)
+            {
+                result.ShouldStopTimer = true;
+                result.ShouldClose = true;
+
+                if (this.AutoClose.Mode == AutoCloseDefinedParameters.Result)
+                {
+                    result.UseDirectResult = true;
+                    result.DirectResult = this.AutoClose.Result;
+                }
+                else
+                {
+                    int buttonIndex = this.GetAutoCloseButtonIndex(buttonCount);
+                    if (buttonIndex >= 0)
+                    {
+                        result.ButtonIndex = buttonIndex;
+                    }
+                }
+            }
+            else
+            {
+                int buttonIndex = this.GetAutoCloseButtonIndex(buttonCount);
+                result.ButtonIndex = buttonIndex;
+                result.ShouldClose = false;
+            }
+
+            return result;
+        }
+
+        public string FormatAutoCloseButtonText(string currentText, int secondsRemaining)
+        {
+            Regex extractLabel = new Regex(@".*?\(\d+\)");
+
+            if (extractLabel.IsMatch(currentText))
+            {
+                return String.Format(CultureInfo.InvariantCulture, "{0} ({1})",
+                    currentText.Substring(0, currentText.LastIndexOf(" (", StringComparison.OrdinalIgnoreCase)),
+                    secondsRemaining);
+            }
+            else
+            {
+                return String.Format(CultureInfo.InvariantCulture, "{0} ({1})", currentText, secondsRemaining);
+            }
+        }
+
+        public int GetAutoCloseSecondsRemaining(int elapsedTime)
+        {
+            if (this.AutoClose == null)
+            {
+                return 0;
+            }
+
+            return this.AutoClose.Seconds - elapsedTime;
+        }
+
+        #endregion Business Logic
+    }
+}

--- a/InfoBox/Internals/ParameterParser.cs
+++ b/InfoBox/Internals/ParameterParser.cs
@@ -1,0 +1,314 @@
+namespace InfoBox.Internals
+{
+    using System;
+    using System.Drawing;
+    using System.Windows.Forms;
+
+    internal static class ParameterParser
+    {
+        internal static InformationBoxViewModel Parse(string text, params object[] parameters)
+        {
+            var vm = new InformationBoxViewModel { Text = text };
+
+            bool loadScope = true;
+            foreach (object param in parameters)
+            {
+                if (param is InformationBoxInitialization)
+                {
+                    if (InformationBoxInitialization.FromParametersOnly == (InformationBoxInitialization)param)
+                    {
+                        loadScope = false;
+                    }
+                }
+            }
+
+            if (loadScope)
+            {
+                vm.LoadFromScope();
+            }
+
+            int stringCount = 0;
+
+            foreach (object parameter in parameters)
+            {
+                if (null == parameter)
+                {
+                    continue;
+                }
+
+                if (parameter is string)
+                {
+                    if (stringCount == 0)
+                    {
+                        vm.Title = (string)parameter;
+                    }
+                    else if (stringCount == 1)
+                    {
+                        vm.HelpFile = (string)parameter;
+                    }
+                    else if (stringCount == 2)
+                    {
+                        vm.HelpTopic = (string)parameter;
+                    }
+                    else if (stringCount == 3)
+                    {
+                        vm.DoNotShowAgainText = (string)parameter;
+                    }
+
+                    stringCount++;
+                }
+                else if (parameter is InformationBoxButtons)
+                {
+                    vm.Buttons = (InformationBoxButtons)parameter;
+                }
+                else if (parameter is InformationBoxIcon)
+                {
+                    vm.Icon = (InformationBoxIcon)parameter;
+                }
+                else if (parameter is Icon)
+                {
+                    vm.IconType = IconType.UserDefined;
+                    vm.CustomIcon = (Icon)parameter;
+                }
+                else if (parameter is InformationBoxDefaultButton)
+                {
+                    vm.DefaultButton = (InformationBoxDefaultButton)parameter;
+                }
+                else if (parameter is string[])
+                {
+                    string[] labels = (string[])parameter;
+                    if (labels.Length > 0)
+                    {
+                        vm.ButtonUser1Text = labels[0];
+                    }
+
+                    if (labels.Length > 1)
+                    {
+                        vm.ButtonUser2Text = labels[1];
+                    }
+
+                    if (labels.Length > 2)
+                    {
+                        vm.ButtonUser3Text = labels[2];
+                    }
+                }
+                else if (parameter is InformationBoxButtonsLayout)
+                {
+                    vm.ButtonsLayout = (InformationBoxButtonsLayout)parameter;
+                }
+                else if (parameter is InformationBoxAutoSizeMode)
+                {
+                    vm.AutoSizeMode = (InformationBoxAutoSizeMode)parameter;
+                }
+                else if (parameter is InformationBoxPosition)
+                {
+                    vm.Position = (InformationBoxPosition)parameter;
+                }
+                else if (parameter is bool)
+                {
+                    vm.ShowHelpButton = (bool)parameter;
+                }
+                else if (parameter is HelpNavigator)
+                {
+                    vm.HelpNavigator = (HelpNavigator)parameter;
+                }
+                else if (parameter is InformationBoxCheckBox)
+                {
+                    vm.CheckBox = (InformationBoxCheckBox)parameter;
+                }
+                else if (parameter is InformationBoxStyle)
+                {
+                    vm.Style = (InformationBoxStyle)parameter;
+                }
+                else if (parameter is AutoCloseParameters)
+                {
+                    vm.AutoClose = (AutoCloseParameters)parameter;
+                }
+                else if (parameter is DesignParameters)
+                {
+                    vm.Design = (DesignParameters)parameter;
+                }
+                else if (parameter is FontParameters)
+                {
+                    vm.FontParameters = (FontParameters)parameter;
+                }
+                else if (parameter is Font)
+                {
+                    vm.FontParameters = new FontParameters((Font)parameter);
+                }
+                else if (parameter is InformationBoxTitleIconStyle)
+                {
+                    vm.TitleStyle = (InformationBoxTitleIconStyle)parameter;
+                }
+                else if (parameter is InformationBoxTitleIcon)
+                {
+                    vm.TitleIcon = ((InformationBoxTitleIcon)parameter).Icon;
+                }
+                else if (parameter is MessageBoxButtons?)
+                {
+                    vm.Buttons = MessageBoxEnumConverter.Parse((MessageBoxButtons)parameter);
+                }
+                else if (parameter is MessageBoxIcon?)
+                {
+                    vm.Icon = MessageBoxEnumConverter.Parse((MessageBoxIcon)parameter);
+                }
+                else if (parameter is MessageBoxDefaultButton?)
+                {
+                    vm.DefaultButton = MessageBoxEnumConverter.Parse((MessageBoxDefaultButton)parameter);
+                }
+                else if (parameter is InformationBoxBehavior)
+                {
+                    vm.Behavior = (InformationBoxBehavior)parameter;
+                }
+                else if (parameter is AsyncResultCallback)
+                {
+                    vm.Callback = (AsyncResultCallback)parameter;
+                }
+                else if (parameter is InformationBoxOpacity)
+                {
+                    vm.Opacity = (InformationBoxOpacity)parameter;
+                }
+                else if (parameter is Form)
+                {
+                    vm.Parent = (Form)parameter;
+                }
+                else if (parameter is InformationBoxOrder)
+                {
+                    vm.Order = (InformationBoxOrder)parameter;
+                }
+                else if (parameter is InformationBoxSound)
+                {
+                    vm.Sound = (InformationBoxSound)parameter;
+                }
+            }
+
+            return vm;
+        }
+
+        internal static InformationBoxViewModel ParseNamed(
+            string text,
+            string title = "",
+            string helpFile = "",
+            string helpTopic = "",
+            InformationBoxInitialization initialization = InformationBoxInitialization.FromScopeAndParameters,
+            InformationBoxButtons buttons = InformationBoxButtons.OK,
+            InformationBoxIcon icon = InformationBoxIcon.None,
+            Icon customIcon = null,
+            InformationBoxDefaultButton defaultButton = InformationBoxDefaultButton.Button1,
+            string[] customButtons = null,
+            InformationBoxButtonsLayout buttonsLayout = InformationBoxButtonsLayout.GroupMiddle,
+            InformationBoxAutoSizeMode autoSizeMode = InformationBoxAutoSizeMode.None,
+            InformationBoxPosition position = InformationBoxPosition.CenterOnParent,
+            bool showHelpButton = false,
+            HelpNavigator helpNavigator = HelpNavigator.TableOfContents,
+            InformationBoxCheckBox showDoNotShowAgainCheckBox = 0,
+            string doNotShowAgainText = null,
+            InformationBoxStyle style = InformationBoxStyle.Standard,
+            AutoCloseParameters autoClose = null,
+            DesignParameters design = null,
+            FontParameters fontParameters = null,
+            Font font = null,
+            InformationBoxTitleIconStyle titleStyle = InformationBoxTitleIconStyle.None,
+            InformationBoxTitleIcon titleIcon = null,
+            MessageBoxButtons? legacyButtons = null,
+            MessageBoxIcon? legacyIcon = null,
+            MessageBoxDefaultButton? legacyDefaultButton = null,
+            InformationBoxBehavior behavior = InformationBoxBehavior.Modal,
+            AsyncResultCallback callback = null,
+            InformationBoxOpacity opacity = InformationBoxOpacity.NoFade,
+            Form parent = null,
+            InformationBoxOrder order = InformationBoxOrder.Default,
+            InformationBoxSound sound = InformationBoxSound.Default)
+        {
+            var vm = new InformationBoxViewModel { Text = text };
+
+            if (InformationBoxInitialization.FromParametersOnly == initialization)
+            {
+                vm.LoadFromScope();
+            }
+
+            vm.Title = title;
+            vm.HelpFile = helpFile;
+            vm.HelpTopic = helpTopic;
+            vm.Buttons = buttons;
+            vm.Icon = icon;
+
+            if (customIcon != null)
+            {
+                vm.IconType = IconType.UserDefined;
+                vm.CustomIcon = customIcon;
+            }
+
+            vm.DefaultButton = defaultButton;
+
+            if (customButtons != null)
+            {
+                if (customButtons.Length > 0)
+                {
+                    vm.ButtonUser1Text = customButtons[0];
+                }
+
+                if (customButtons.Length > 1)
+                {
+                    vm.ButtonUser2Text = customButtons[1];
+                }
+
+                if (customButtons.Length > 2)
+                {
+                    vm.ButtonUser3Text = customButtons[2];
+                }
+            }
+
+            vm.ButtonsLayout = buttonsLayout;
+            vm.AutoSizeMode = autoSizeMode;
+            vm.Position = position;
+            vm.ShowHelpButton = showHelpButton;
+            vm.HelpNavigator = helpNavigator;
+            vm.CheckBox = showDoNotShowAgainCheckBox;
+            vm.DoNotShowAgainText = doNotShowAgainText;
+            vm.Style = style;
+            vm.AutoClose = autoClose;
+            vm.Design = design;
+
+            if (font != null)
+            {
+                vm.FontParameters = new FontParameters(font);
+            }
+            else
+            {
+                vm.FontParameters = fontParameters;
+            }
+
+            vm.TitleStyle = titleStyle;
+
+            if (titleIcon != null)
+            {
+                vm.TitleIcon = titleIcon.Icon;
+            }
+
+            if (legacyButtons.HasValue)
+            {
+                vm.Buttons = MessageBoxEnumConverter.Parse(legacyButtons.Value);
+            }
+
+            if (legacyIcon.HasValue)
+            {
+                vm.Icon = MessageBoxEnumConverter.Parse(legacyIcon.Value);
+            }
+
+            if (legacyDefaultButton.HasValue)
+            {
+                vm.DefaultButton = MessageBoxEnumConverter.Parse(legacyDefaultButton.Value);
+            }
+
+            vm.Behavior = behavior;
+            vm.Callback = callback;
+            vm.Opacity = opacity;
+            vm.Parent = parent;
+            vm.Order = order;
+            vm.Sound = sound;
+
+            return vm;
+        }
+    }
+}

--- a/InfoBox/Internals/ViewModelTypes.cs
+++ b/InfoBox/Internals/ViewModelTypes.cs
@@ -1,0 +1,49 @@
+namespace InfoBox.Internals
+{
+    using System.Drawing;
+    using System.Windows.Forms;
+
+    internal struct ButtonDefinition
+    {
+        public string Name { get; set; }
+        public string Text { get; set; }
+    }
+
+    internal struct CheckBoxConfiguration
+    {
+        public string Text { get; set; }
+        public bool Visible { get; set; }
+        public bool Checked { get; set; }
+        public ContentAlignment TextAlign { get; set; }
+        public ContentAlignment CheckAlign { get; set; }
+    }
+
+    internal struct WindowStyleConfiguration
+    {
+        public Color BarsBackColor { get; set; }
+        public Color FormBackColor { get; set; }
+        public FormBorderStyle BorderStyle { get; set; }
+        public bool TitleLabelVisible { get; set; }
+        public bool AdjustPanelTop { get; set; }
+        public bool RemoveSideBorder { get; set; }
+    }
+
+    internal struct IconConfiguration
+    {
+        public bool IconPanelVisible { get; set; }
+        public Image IconImage { get; set; }
+        public bool ShowFormIcon { get; set; }
+        public Icon FormIcon { get; set; }
+    }
+
+    internal struct AutoCloseTickResult
+    {
+        public bool ShouldClose { get; set; }
+        public bool ShouldStopTimer { get; set; }
+        public string ButtonName { get; set; }
+        public int ButtonIndex { get; set; }
+        public InformationBoxResult DirectResult { get; set; }
+        public bool UseDirectResult { get; set; }
+        public string UpdatedButtonText { get; set; }
+    }
+}

--- a/InfoBox/Internals/WinFormsScreenProvider.cs
+++ b/InfoBox/Internals/WinFormsScreenProvider.cs
@@ -1,0 +1,10 @@
+namespace InfoBox.Internals
+{
+    using System.Drawing;
+    using System.Windows.Forms;
+
+    internal class WinFormsScreenProvider : IScreenProvider
+    {
+        public Rectangle WorkingArea => Screen.PrimaryScreen.WorkingArea;
+    }
+}

--- a/InfoBox/Internals/WinFormsTextMeasurer.cs
+++ b/InfoBox/Internals/WinFormsTextMeasurer.cs
@@ -1,0 +1,13 @@
+namespace InfoBox.Internals
+{
+    using System.Drawing;
+    using System.Windows.Forms;
+
+    internal class WinFormsTextMeasurer : ITextMeasurer
+    {
+        public Size MeasureText(string text, Font font, Size proposedSize, TextFormatFlags flags)
+        {
+            return TextRenderer.MeasureText(text, font, proposedSize, flags);
+        }
+    }
+}

--- a/InfoBoxCore.Tests/Fakes/FakeScreenProvider.cs
+++ b/InfoBoxCore.Tests/Fakes/FakeScreenProvider.cs
@@ -1,0 +1,10 @@
+using System.Drawing;
+using InfoBox.Internals;
+
+namespace InfoBoxCore.Tests.Fakes
+{
+    internal class FakeScreenProvider : IScreenProvider
+    {
+        public Rectangle WorkingArea { get; set; } = new Rectangle(0, 0, 1920, 1080);
+    }
+}

--- a/InfoBoxCore.Tests/Fakes/FakeTextMeasurer.cs
+++ b/InfoBoxCore.Tests/Fakes/FakeTextMeasurer.cs
@@ -1,0 +1,22 @@
+using System.Drawing;
+using System.Windows.Forms;
+using InfoBox.Internals;
+
+namespace InfoBoxCore.Tests.Fakes
+{
+    internal class FakeTextMeasurer : ITextMeasurer
+    {
+        public int WidthPerChar { get; set; } = 8;
+        public int LineHeight { get; set; } = 16;
+
+        public Size MeasureText(string text, Font font, Size proposedSize, TextFormatFlags flags)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return new Size(0, LineHeight);
+            }
+
+            return new Size(text.Length * WidthPerChar, LineHeight);
+        }
+    }
+}

--- a/InfoBoxCore.Tests/InformationBoxViewModelTests.cs
+++ b/InfoBoxCore.Tests/InformationBoxViewModelTests.cs
@@ -511,10 +511,11 @@ namespace InfoBoxCore.Tests
         [Test]
         public void GetWindowStyleConfiguration_ModernWithDesign_UsesDesignColors()
         {
+            // DesignParameters constructor: (formBackColor, barsBackColor)
             var vm = new InformationBoxViewModel
             {
                 Style = InformationBoxStyle.Modern,
-                Design = new DesignParameters(Color.DarkBlue, Color.LightGray),
+                Design = new DesignParameters(Color.LightGray, Color.DarkBlue),
             };
             var config = vm.GetWindowStyleConfiguration();
 
@@ -535,10 +536,11 @@ namespace InfoBoxCore.Tests
         [Test]
         public void GetWindowStyleConfiguration_StandardWithDesign_UsesDesignColors()
         {
+            // DesignParameters constructor: (formBackColor, barsBackColor)
             var vm = new InformationBoxViewModel
             {
                 Style = InformationBoxStyle.Standard,
-                Design = new DesignParameters(Color.Navy, Color.Ivory),
+                Design = new DesignParameters(Color.Ivory, Color.Navy),
             };
             var config = vm.GetWindowStyleConfiguration();
 

--- a/InfoBoxCore.Tests/InformationBoxViewModelTests.cs
+++ b/InfoBoxCore.Tests/InformationBoxViewModelTests.cs
@@ -1,0 +1,744 @@
+using System.Drawing;
+using System.Media;
+using System.Windows.Forms;
+using InfoBox;
+using InfoBox.Internals;
+using NUnit.Framework;
+
+namespace InfoBoxCore.Tests
+{
+    [TestFixture]
+    public class InformationBoxViewModelTests
+    {
+        #region Default Values
+
+        [Test]
+        public void DefaultValues_AreCorrect()
+        {
+            var vm = new InformationBoxViewModel();
+
+            Assert.That(vm.Text, Is.EqualTo(string.Empty));
+            Assert.That(vm.Title, Is.EqualTo(string.Empty));
+            Assert.That(vm.HelpFile, Is.EqualTo(string.Empty));
+            Assert.That(vm.HelpTopic, Is.EqualTo(string.Empty));
+            Assert.That(vm.ButtonUser1Text, Is.EqualTo("User1"));
+            Assert.That(vm.ButtonUser2Text, Is.EqualTo("User2"));
+            Assert.That(vm.ButtonUser3Text, Is.EqualTo("User3"));
+            Assert.That(vm.DoNotShowAgainText, Is.Null);
+            Assert.That(vm.Buttons, Is.EqualTo(InformationBoxButtons.OK));
+            Assert.That(vm.Icon, Is.EqualTo(InformationBoxIcon.None));
+            Assert.That(vm.CustomIcon, Is.Null);
+            Assert.That(vm.IconType, Is.EqualTo(IconType.Internal));
+            Assert.That(vm.DefaultButton, Is.EqualTo(InformationBoxDefaultButton.Button1));
+            Assert.That(vm.ButtonsLayout, Is.EqualTo(InformationBoxButtonsLayout.GroupMiddle));
+            Assert.That(vm.AutoSizeMode, Is.EqualTo(InformationBoxAutoSizeMode.None));
+            Assert.That(vm.Position, Is.EqualTo(InformationBoxPosition.CenterOnParent));
+            Assert.That(vm.Style, Is.EqualTo(InformationBoxStyle.Standard));
+            Assert.That(vm.Behavior, Is.EqualTo(InformationBoxBehavior.Modal));
+            Assert.That(vm.Opacity, Is.EqualTo(InformationBoxOpacity.NoFade));
+            Assert.That(vm.Order, Is.EqualTo(InformationBoxOrder.Default));
+            Assert.That(vm.Sound, Is.EqualTo(InformationBoxSound.Default));
+            Assert.That(vm.ShowHelpButton, Is.False);
+            Assert.That(vm.AutoClose, Is.Null);
+            Assert.That(vm.Design, Is.Null);
+            Assert.That(vm.FontParameters, Is.Null);
+            Assert.That(vm.TitleStyle, Is.EqualTo(InformationBoxTitleIconStyle.None));
+            Assert.That(vm.TitleIcon, Is.Null);
+            Assert.That(vm.Callback, Is.Null);
+            Assert.That(vm.Parent, Is.Null);
+        }
+
+        #endregion
+
+        #region GetButtonDefinitions
+
+        [Test]
+        public void GetButtonDefinitions_OK_ReturnsOneOKButton()
+        {
+            var vm = new InformationBoxViewModel { Buttons = InformationBoxButtons.OK };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(1));
+            Assert.That(buttons[0].Name, Is.EqualTo("OK"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_OKCancel_ReturnsTwoButtons()
+        {
+            var vm = new InformationBoxViewModel { Buttons = InformationBoxButtons.OKCancel };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(2));
+            Assert.That(buttons[0].Name, Is.EqualTo("OK"));
+            Assert.That(buttons[1].Name, Is.EqualTo("Cancel"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_YesNoCancel_ReturnsThreeButtons()
+        {
+            var vm = new InformationBoxViewModel { Buttons = InformationBoxButtons.YesNoCancel };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(3));
+            Assert.That(buttons[0].Name, Is.EqualTo("Yes"));
+            Assert.That(buttons[1].Name, Is.EqualTo("No"));
+            Assert.That(buttons[2].Name, Is.EqualTo("Cancel"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_AbortRetryIgnore_ReturnsThreeButtons()
+        {
+            var vm = new InformationBoxViewModel { Buttons = InformationBoxButtons.AbortRetryIgnore };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(3));
+            Assert.That(buttons[0].Name, Is.EqualTo("Abort"));
+            Assert.That(buttons[1].Name, Is.EqualTo("Retry"));
+            Assert.That(buttons[2].Name, Is.EqualTo("Ignore"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_RetryCancel_ReturnsTwoButtons()
+        {
+            var vm = new InformationBoxViewModel { Buttons = InformationBoxButtons.RetryCancel };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(2));
+            Assert.That(buttons[0].Name, Is.EqualTo("Retry"));
+            Assert.That(buttons[1].Name, Is.EqualTo("Cancel"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_YesNo_ReturnsTwoButtons()
+        {
+            var vm = new InformationBoxViewModel { Buttons = InformationBoxButtons.YesNo };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(2));
+            Assert.That(buttons[0].Name, Is.EqualTo("Yes"));
+            Assert.That(buttons[1].Name, Is.EqualTo("No"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_User1User2User3_ReturnsThreeCustomButtons()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Buttons = InformationBoxButtons.User1User2User3,
+                ButtonUser1Text = "Save",
+                ButtonUser2Text = "Discard",
+                ButtonUser3Text = "Cancel",
+            };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(3));
+            Assert.That(buttons[0].Name, Is.EqualTo("User1"));
+            Assert.That(buttons[0].Text, Is.EqualTo("Save"));
+            Assert.That(buttons[1].Name, Is.EqualTo("User2"));
+            Assert.That(buttons[1].Text, Is.EqualTo("Discard"));
+            Assert.That(buttons[2].Name, Is.EqualTo("User3"));
+            Assert.That(buttons[2].Text, Is.EqualTo("Cancel"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_User1_ReturnsSingleCustomButton()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Buttons = InformationBoxButtons.User1,
+                ButtonUser1Text = "Custom",
+            };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(1));
+            Assert.That(buttons[0].Name, Is.EqualTo("User1"));
+            Assert.That(buttons[0].Text, Is.EqualTo("Custom"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_WithHelpButton_IncludesHelp()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Buttons = InformationBoxButtons.OK,
+                ShowHelpButton = true,
+            };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(2));
+            Assert.That(buttons[1].Name, Is.EqualTo("Help"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_WithHelpFile_IncludesHelp()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Buttons = InformationBoxButtons.OK,
+                HelpFile = "help.chm",
+            };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(2));
+            Assert.That(buttons[1].Name, Is.EqualTo("Help"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_OKCancelUser1_ReturnsThreeButtons()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Buttons = InformationBoxButtons.OKCancelUser1,
+                ButtonUser1Text = "Custom",
+            };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(3));
+            Assert.That(buttons[0].Name, Is.EqualTo("OK"));
+            Assert.That(buttons[1].Name, Is.EqualTo("Cancel"));
+            Assert.That(buttons[2].Name, Is.EqualTo("User1"));
+            Assert.That(buttons[2].Text, Is.EqualTo("Custom"));
+        }
+
+        [Test]
+        public void GetButtonDefinitions_YesNoUser1_ReturnsThreeButtons()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Buttons = InformationBoxButtons.YesNoUser1,
+                ButtonUser1Text = "Maybe",
+            };
+            var buttons = vm.GetButtonDefinitions();
+
+            Assert.That(buttons.Length, Is.EqualTo(3));
+            Assert.That(buttons[0].Name, Is.EqualTo("Yes"));
+            Assert.That(buttons[1].Name, Is.EqualTo("No"));
+            Assert.That(buttons[2].Name, Is.EqualTo("User1"));
+            Assert.That(buttons[2].Text, Is.EqualTo("Maybe"));
+        }
+
+        #endregion
+
+        #region MapButtonNameToResult
+
+        [Test]
+        public void MapButtonNameToResult_OK_ReturnsOK()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("OK"), Is.EqualTo(InformationBoxResult.OK));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_Yes_ReturnsYes()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("Yes"), Is.EqualTo(InformationBoxResult.Yes));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_No_ReturnsNo()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("No"), Is.EqualTo(InformationBoxResult.No));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_Cancel_ReturnsCancel()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("Cancel"), Is.EqualTo(InformationBoxResult.Cancel));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_Abort_ReturnsAbort()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("Abort"), Is.EqualTo(InformationBoxResult.Abort));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_Retry_ReturnsRetry()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("Retry"), Is.EqualTo(InformationBoxResult.Retry));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_Ignore_ReturnsIgnore()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("Ignore"), Is.EqualTo(InformationBoxResult.Ignore));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_User1_ReturnsUser1()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("User1"), Is.EqualTo(InformationBoxResult.User1));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_User2_ReturnsUser2()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("User2"), Is.EqualTo(InformationBoxResult.User2));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_User3_ReturnsUser3()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("User3"), Is.EqualTo(InformationBoxResult.User3));
+        }
+
+        [Test]
+        public void MapButtonNameToResult_Unknown_ReturnsNone()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.MapButtonNameToResult("Unknown"), Is.EqualTo(InformationBoxResult.None));
+        }
+
+        #endregion
+
+        #region IsHelpButton
+
+        [Test]
+        public void IsHelpButton_Help_ReturnsTrue()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.IsHelpButton("Help"), Is.True);
+        }
+
+        [Test]
+        public void IsHelpButton_OK_ReturnsFalse()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.IsHelpButton("OK"), Is.False);
+        }
+
+        #endregion
+
+        #region GetOpacityValue
+
+        [Test]
+        public void GetOpacityValue_NoFade_Returns1()
+        {
+            var vm = new InformationBoxViewModel { Opacity = InformationBoxOpacity.NoFade };
+            Assert.That(vm.GetOpacityValue(), Is.EqualTo(1.0));
+        }
+
+        [Test]
+        public void GetOpacityValue_Faded50_Returns05()
+        {
+            var vm = new InformationBoxViewModel { Opacity = InformationBoxOpacity.Faded50 };
+            Assert.That(vm.GetOpacityValue(), Is.EqualTo(0.5));
+        }
+
+        [Test]
+        public void GetOpacityValue_Faded10_Returns01()
+        {
+            var vm = new InformationBoxViewModel { Opacity = InformationBoxOpacity.Faded10 };
+            Assert.That(vm.GetOpacityValue(), Is.EqualTo(0.1));
+        }
+
+        [Test]
+        public void GetOpacityValue_Faded90_Returns09()
+        {
+            var vm = new InformationBoxViewModel { Opacity = InformationBoxOpacity.Faded90 };
+            Assert.That(vm.GetOpacityValue(), Is.EqualTo(0.9));
+        }
+
+        #endregion
+
+        #region GetSystemSound
+
+        [Test]
+        public void GetSystemSound_SoundNone_ReturnsNull()
+        {
+            var vm = new InformationBoxViewModel { Sound = InformationBoxSound.None };
+            Assert.That(vm.GetSystemSound(), Is.Null);
+        }
+
+        [Test]
+        public void GetSystemSound_UserDefinedIcon_ReturnsBeep()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Sound = InformationBoxSound.Default,
+                IconType = IconType.UserDefined,
+            };
+            Assert.That(vm.GetSystemSound(), Is.EqualTo(SystemSounds.Beep));
+        }
+
+        [Test]
+        public void GetSystemSound_WarningIcon_ReturnsExclamation()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Sound = InformationBoxSound.Default,
+                Icon = InformationBoxIcon.Warning,
+            };
+            Assert.That(vm.GetSystemSound(), Is.EqualTo(SystemSounds.Exclamation));
+        }
+
+        [Test]
+        public void GetSystemSound_ErrorIcon_ReturnsHand()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Sound = InformationBoxSound.Default,
+                Icon = InformationBoxIcon.Error,
+            };
+            Assert.That(vm.GetSystemSound(), Is.EqualTo(SystemSounds.Hand));
+        }
+
+        [Test]
+        public void GetSystemSound_QuestionIcon_ReturnsQuestion()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Sound = InformationBoxSound.Default,
+                Icon = InformationBoxIcon.Question,
+            };
+            Assert.That(vm.GetSystemSound(), Is.EqualTo(SystemSounds.Question));
+        }
+
+        [Test]
+        public void GetSystemSound_InformationIcon_ReturnsAsterisk()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Sound = InformationBoxSound.Default,
+                Icon = InformationBoxIcon.Information,
+            };
+            Assert.That(vm.GetSystemSound(), Is.EqualTo(SystemSounds.Asterisk));
+        }
+
+        #endregion
+
+        #region GetCheckBoxConfiguration
+
+        [Test]
+        public void GetCheckBoxConfiguration_NotShown_VisibleFalse()
+        {
+            var vm = new InformationBoxViewModel { CheckBox = 0 };
+            var config = vm.GetCheckBoxConfiguration();
+
+            Assert.That(config.Visible, Is.False);
+        }
+
+        [Test]
+        public void GetCheckBoxConfiguration_Shown_VisibleTrue()
+        {
+            var vm = new InformationBoxViewModel { CheckBox = InformationBoxCheckBox.Show };
+            var config = vm.GetCheckBoxConfiguration();
+
+            Assert.That(config.Visible, Is.True);
+            Assert.That(config.Checked, Is.False);
+        }
+
+        [Test]
+        public void GetCheckBoxConfiguration_ShowAndChecked_CheckedTrue()
+        {
+            var vm = new InformationBoxViewModel { CheckBox = InformationBoxCheckBox.Show | InformationBoxCheckBox.Checked };
+            var config = vm.GetCheckBoxConfiguration();
+
+            Assert.That(config.Visible, Is.True);
+            Assert.That(config.Checked, Is.True);
+        }
+
+        [Test]
+        public void GetCheckBoxConfiguration_RightAligned_SetsAlignment()
+        {
+            var vm = new InformationBoxViewModel { CheckBox = InformationBoxCheckBox.Show | InformationBoxCheckBox.RightAligned };
+            var config = vm.GetCheckBoxConfiguration();
+
+            Assert.That(config.TextAlign, Is.EqualTo(ContentAlignment.BottomRight));
+            Assert.That(config.CheckAlign, Is.EqualTo(ContentAlignment.MiddleRight));
+        }
+
+        [Test]
+        public void GetCheckBoxConfiguration_LeftAligned_SetsAlignment()
+        {
+            var vm = new InformationBoxViewModel { CheckBox = InformationBoxCheckBox.Show };
+            var config = vm.GetCheckBoxConfiguration();
+
+            Assert.That(config.TextAlign, Is.EqualTo(ContentAlignment.BottomLeft));
+            Assert.That(config.CheckAlign, Is.EqualTo(ContentAlignment.MiddleLeft));
+        }
+
+        [Test]
+        public void GetCheckBoxConfiguration_CustomText_UsesCustomText()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                CheckBox = InformationBoxCheckBox.Show,
+                DoNotShowAgainText = "Custom text",
+            };
+            var config = vm.GetCheckBoxConfiguration();
+
+            Assert.That(config.Text, Is.EqualTo("Custom text"));
+        }
+
+        #endregion
+
+        #region GetWindowStyleConfiguration
+
+        [Test]
+        public void GetWindowStyleConfiguration_Standard_ReturnsFixedDialog()
+        {
+            var vm = new InformationBoxViewModel { Style = InformationBoxStyle.Standard };
+            var config = vm.GetWindowStyleConfiguration();
+
+            Assert.That(config.BorderStyle, Is.EqualTo(FormBorderStyle.FixedDialog));
+            Assert.That(config.TitleLabelVisible, Is.False);
+            Assert.That(config.AdjustPanelTop, Is.True);
+            Assert.That(config.RemoveSideBorder, Is.True);
+        }
+
+        [Test]
+        public void GetWindowStyleConfiguration_Modern_ReturnsNone()
+        {
+            var vm = new InformationBoxViewModel { Style = InformationBoxStyle.Modern };
+            var config = vm.GetWindowStyleConfiguration();
+
+            Assert.That(config.BorderStyle, Is.EqualTo(FormBorderStyle.None));
+            Assert.That(config.TitleLabelVisible, Is.True);
+            Assert.That(config.AdjustPanelTop, Is.False);
+            Assert.That(config.RemoveSideBorder, Is.False);
+        }
+
+        [Test]
+        public void GetWindowStyleConfiguration_ModernWithDesign_UsesDesignColors()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Style = InformationBoxStyle.Modern,
+                Design = new DesignParameters(Color.DarkBlue, Color.LightGray),
+            };
+            var config = vm.GetWindowStyleConfiguration();
+
+            Assert.That(config.BarsBackColor, Is.EqualTo(Color.DarkBlue));
+            Assert.That(config.FormBackColor, Is.EqualTo(Color.LightGray));
+        }
+
+        [Test]
+        public void GetWindowStyleConfiguration_ModernWithoutDesign_UsesDefaults()
+        {
+            var vm = new InformationBoxViewModel { Style = InformationBoxStyle.Modern };
+            var config = vm.GetWindowStyleConfiguration();
+
+            Assert.That(config.BarsBackColor, Is.EqualTo(Color.Black));
+            Assert.That(config.FormBackColor, Is.EqualTo(Color.Silver));
+        }
+
+        [Test]
+        public void GetWindowStyleConfiguration_StandardWithDesign_UsesDesignColors()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                Style = InformationBoxStyle.Standard,
+                Design = new DesignParameters(Color.Navy, Color.Ivory),
+            };
+            var config = vm.GetWindowStyleConfiguration();
+
+            Assert.That(config.BarsBackColor, Is.EqualTo(Color.Navy));
+            Assert.That(config.FormBackColor, Is.EqualTo(Color.Ivory));
+        }
+
+        #endregion
+
+        #region HasIcon
+
+        [Test]
+        public void HasIcon_NoIcon_ReturnsFalse()
+        {
+            var vm = new InformationBoxViewModel { Icon = InformationBoxIcon.None, IconType = IconType.Internal };
+            Assert.That(vm.HasIcon(), Is.False);
+        }
+
+        [Test]
+        public void HasIcon_InternalIcon_ReturnsTrue()
+        {
+            var vm = new InformationBoxViewModel { Icon = InformationBoxIcon.Warning };
+            Assert.That(vm.HasIcon(), Is.True);
+        }
+
+        [Test]
+        public void HasIcon_UserDefinedIcon_ReturnsTrue()
+        {
+            var vm = new InformationBoxViewModel { IconType = IconType.UserDefined };
+            Assert.That(vm.HasIcon(), Is.True);
+        }
+
+        #endregion
+
+        #region HasCheckBox
+
+        [Test]
+        public void HasCheckBox_NotShown_ReturnsFalse()
+        {
+            var vm = new InformationBoxViewModel { CheckBox = 0 };
+            Assert.That(vm.HasCheckBox(), Is.False);
+        }
+
+        [Test]
+        public void HasCheckBox_Shown_ReturnsTrue()
+        {
+            var vm = new InformationBoxViewModel { CheckBox = InformationBoxCheckBox.Show };
+            Assert.That(vm.HasCheckBox(), Is.True);
+        }
+
+        #endregion
+
+        #region AutoClose
+
+        [Test]
+        public void GetAutoCloseButtonIndex_NoAutoClose_ReturnsNegative()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.GetAutoCloseButtonIndex(3), Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void GetAutoCloseButtonIndex_ButtonMode_ReturnsCorrectIndex()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                AutoClose = new AutoCloseParameters(10, InformationBoxDefaultButton.Button2),
+            };
+            Assert.That(vm.GetAutoCloseButtonIndex(3), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void GetAutoCloseButtonIndex_TimeOnlyMode_UsesDefaultButton()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                AutoClose = new AutoCloseParameters(10),
+                DefaultButton = InformationBoxDefaultButton.Button1,
+            };
+            Assert.That(vm.GetAutoCloseButtonIndex(3), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void GetAutoCloseButtonIndex_ButtonExceedsCount_ReturnsNegative()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                AutoClose = new AutoCloseParameters(10, InformationBoxDefaultButton.Button3),
+            };
+            Assert.That(vm.GetAutoCloseButtonIndex(2), Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void ProcessAutoCloseTick_TimeReached_ShouldClose()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                AutoClose = new AutoCloseParameters(5),
+                DefaultButton = InformationBoxDefaultButton.Button1,
+            };
+
+            var result = vm.ProcessAutoCloseTick(5, 2);
+
+            Assert.That(result.ShouldClose, Is.True);
+            Assert.That(result.ShouldStopTimer, Is.True);
+        }
+
+        [Test]
+        public void ProcessAutoCloseTick_TimeNotReached_ShouldNotClose()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                AutoClose = new AutoCloseParameters(10),
+                DefaultButton = InformationBoxDefaultButton.Button1,
+            };
+
+            var result = vm.ProcessAutoCloseTick(3, 2);
+
+            Assert.That(result.ShouldClose, Is.False);
+            Assert.That(result.ShouldStopTimer, Is.False);
+        }
+
+        [Test]
+        public void ProcessAutoCloseTick_ResultMode_SetsDirectResult()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                AutoClose = new AutoCloseParameters(5, InformationBoxResult.Yes),
+            };
+
+            var result = vm.ProcessAutoCloseTick(5, 2);
+
+            Assert.That(result.ShouldClose, Is.True);
+            Assert.That(result.UseDirectResult, Is.True);
+            Assert.That(result.DirectResult, Is.EqualTo(InformationBoxResult.Yes));
+        }
+
+        [Test]
+        public void ProcessAutoCloseTick_NoAutoClose_ReturnsDefault()
+        {
+            var vm = new InformationBoxViewModel();
+            var result = vm.ProcessAutoCloseTick(0, 2);
+
+            Assert.That(result.ShouldClose, Is.False);
+            Assert.That(result.ButtonIndex, Is.EqualTo(-1));
+        }
+
+        #endregion
+
+        #region FormatAutoCloseButtonText
+
+        [Test]
+        public void FormatAutoCloseButtonText_FirstCall_AppendsCountdown()
+        {
+            var vm = new InformationBoxViewModel();
+            var text = vm.FormatAutoCloseButtonText("OK", 10);
+
+            Assert.That(text, Is.EqualTo("OK (10)"));
+        }
+
+        [Test]
+        public void FormatAutoCloseButtonText_Subsequent_UpdatesCountdown()
+        {
+            var vm = new InformationBoxViewModel();
+            var text = vm.FormatAutoCloseButtonText("OK (10)", 9);
+
+            Assert.That(text, Is.EqualTo("OK (9)"));
+        }
+
+        [Test]
+        public void FormatAutoCloseButtonText_MultiDigit_UpdatesCorrectly()
+        {
+            var vm = new InformationBoxViewModel();
+            var text = vm.FormatAutoCloseButtonText("OK (100)", 5);
+
+            Assert.That(text, Is.EqualTo("OK (5)"));
+        }
+
+        #endregion
+
+        #region GetAutoCloseSecondsRemaining
+
+        [Test]
+        public void GetAutoCloseSecondsRemaining_ReturnsCorrectValue()
+        {
+            var vm = new InformationBoxViewModel
+            {
+                AutoClose = new AutoCloseParameters(30),
+            };
+
+            Assert.That(vm.GetAutoCloseSecondsRemaining(10), Is.EqualTo(20));
+        }
+
+        [Test]
+        public void GetAutoCloseSecondsRemaining_NoAutoClose_ReturnsZero()
+        {
+            var vm = new InformationBoxViewModel();
+            Assert.That(vm.GetAutoCloseSecondsRemaining(5), Is.EqualTo(0));
+        }
+
+        #endregion
+    }
+}

--- a/InfoBoxCore.Tests/ParameterParserTests.cs
+++ b/InfoBoxCore.Tests/ParameterParserTests.cs
@@ -1,0 +1,361 @@
+using System.Drawing;
+using System.Windows.Forms;
+using InfoBox;
+using InfoBox.Internals;
+using NUnit.Framework;
+
+namespace InfoBoxCore.Tests
+{
+    [TestFixture]
+    public class ParameterParserTests
+    {
+        #region Basic Parsing
+
+        [Test]
+        public void Parse_WithTextOnly_SetsTextAndDefaults()
+        {
+            var vm = ParameterParser.Parse("Hello");
+
+            Assert.That(vm.Text, Is.EqualTo("Hello"));
+            Assert.That(vm.Title, Is.EqualTo(string.Empty));
+            Assert.That(vm.Buttons, Is.EqualTo(InformationBoxButtons.OK));
+            Assert.That(vm.Icon, Is.EqualTo(InformationBoxIcon.None));
+            Assert.That(vm.DefaultButton, Is.EqualTo(InformationBoxDefaultButton.Button1));
+            Assert.That(vm.ButtonsLayout, Is.EqualTo(InformationBoxButtonsLayout.GroupMiddle));
+            Assert.That(vm.AutoSizeMode, Is.EqualTo(InformationBoxAutoSizeMode.None));
+            Assert.That(vm.Position, Is.EqualTo(InformationBoxPosition.CenterOnParent));
+            Assert.That(vm.Style, Is.EqualTo(InformationBoxStyle.Standard));
+            Assert.That(vm.Behavior, Is.EqualTo(InformationBoxBehavior.Modal));
+            Assert.That(vm.Opacity, Is.EqualTo(InformationBoxOpacity.NoFade));
+            Assert.That(vm.Order, Is.EqualTo(InformationBoxOrder.Default));
+            Assert.That(vm.Sound, Is.EqualTo(InformationBoxSound.Default));
+        }
+
+        [Test]
+        public void Parse_NullParameters_AreSkipped()
+        {
+            var vm = ParameterParser.Parse("Hello", null, "Title");
+
+            Assert.That(vm.Text, Is.EqualTo("Hello"));
+            Assert.That(vm.Title, Is.EqualTo("Title"));
+        }
+
+        #endregion
+
+        #region String Parameters
+
+        [Test]
+        public void Parse_FirstString_SetsTitleAndLblTitle()
+        {
+            var vm = ParameterParser.Parse("Hello", "My Title");
+
+            Assert.That(vm.Title, Is.EqualTo("My Title"));
+        }
+
+        [Test]
+        public void Parse_SecondString_SetsHelpFile()
+        {
+            var vm = ParameterParser.Parse("Hello", "Title", "help.chm");
+
+            Assert.That(vm.HelpFile, Is.EqualTo("help.chm"));
+        }
+
+        [Test]
+        public void Parse_ThirdString_SetsHelpTopic()
+        {
+            var vm = ParameterParser.Parse("Hello", "Title", "help.chm", "topic1");
+
+            Assert.That(vm.HelpTopic, Is.EqualTo("topic1"));
+        }
+
+        [Test]
+        public void Parse_FourthString_SetsDoNotShowAgainText()
+        {
+            var vm = ParameterParser.Parse("Hello", "Title", "help.chm", "topic1", "Don't show");
+
+            Assert.That(vm.DoNotShowAgainText, Is.EqualTo("Don't show"));
+        }
+
+        #endregion
+
+        #region Enum Parameters
+
+        [Test]
+        public void Parse_InformationBoxButtons_SetsButtons()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxButtons.YesNoCancel);
+
+            Assert.That(vm.Buttons, Is.EqualTo(InformationBoxButtons.YesNoCancel));
+        }
+
+        [Test]
+        public void Parse_InformationBoxIcon_SetsIcon()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxIcon.Warning);
+
+            Assert.That(vm.Icon, Is.EqualTo(InformationBoxIcon.Warning));
+        }
+
+        [Test]
+        public void Parse_InformationBoxDefaultButton_SetsDefaultButton()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxDefaultButton.Button2);
+
+            Assert.That(vm.DefaultButton, Is.EqualTo(InformationBoxDefaultButton.Button2));
+        }
+
+        [Test]
+        public void Parse_InformationBoxButtonsLayout_SetsLayout()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxButtonsLayout.GroupRight);
+
+            Assert.That(vm.ButtonsLayout, Is.EqualTo(InformationBoxButtonsLayout.GroupRight));
+        }
+
+        [Test]
+        public void Parse_InformationBoxAutoSizeMode_SetsAutoSizeMode()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxAutoSizeMode.MinimumWidth);
+
+            Assert.That(vm.AutoSizeMode, Is.EqualTo(InformationBoxAutoSizeMode.MinimumWidth));
+        }
+
+        [Test]
+        public void Parse_InformationBoxPosition_SetsPosition()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxPosition.CenterOnScreen);
+
+            Assert.That(vm.Position, Is.EqualTo(InformationBoxPosition.CenterOnScreen));
+        }
+
+        [Test]
+        public void Parse_InformationBoxCheckBox_SetsCheckBox()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxCheckBox.Show);
+
+            Assert.That(vm.CheckBox, Is.EqualTo(InformationBoxCheckBox.Show));
+        }
+
+        [Test]
+        public void Parse_InformationBoxStyle_SetsStyle()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxStyle.Modern);
+
+            Assert.That(vm.Style, Is.EqualTo(InformationBoxStyle.Modern));
+        }
+
+        [Test]
+        public void Parse_InformationBoxBehavior_SetsBehavior()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxBehavior.Modeless);
+
+            Assert.That(vm.Behavior, Is.EqualTo(InformationBoxBehavior.Modeless));
+        }
+
+        [Test]
+        public void Parse_InformationBoxOpacity_SetsOpacity()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxOpacity.Faded50);
+
+            Assert.That(vm.Opacity, Is.EqualTo(InformationBoxOpacity.Faded50));
+        }
+
+        [Test]
+        public void Parse_InformationBoxOrder_SetsOrder()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxOrder.TopMost);
+
+            Assert.That(vm.Order, Is.EqualTo(InformationBoxOrder.TopMost));
+        }
+
+        [Test]
+        public void Parse_InformationBoxSound_SetsSound()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxSound.None);
+
+            Assert.That(vm.Sound, Is.EqualTo(InformationBoxSound.None));
+        }
+
+        [Test]
+        public void Parse_InformationBoxTitleIconStyle_SetsTitleStyle()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxTitleIconStyle.SameAsBox);
+
+            Assert.That(vm.TitleStyle, Is.EqualTo(InformationBoxTitleIconStyle.SameAsBox));
+        }
+
+        [Test]
+        public void Parse_BoolTrue_SetsShowHelpButton()
+        {
+            var vm = ParameterParser.Parse("Hello", true);
+
+            Assert.That(vm.ShowHelpButton, Is.True);
+        }
+
+        [Test]
+        public void Parse_HelpNavigator_SetsHelpNavigator()
+        {
+            var vm = ParameterParser.Parse("Hello", HelpNavigator.Index);
+
+            Assert.That(vm.HelpNavigator, Is.EqualTo(HelpNavigator.Index));
+        }
+
+        #endregion
+
+        #region Complex Parameters
+
+        [Test]
+        public void Parse_CustomIcon_SetsIconTypeAndCustomIcon()
+        {
+            var icon = SystemIcons.Application;
+            var vm = ParameterParser.Parse("Hello", icon);
+
+            Assert.That(vm.IconType, Is.EqualTo(IconType.UserDefined));
+            Assert.That(vm.CustomIcon, Is.SameAs(icon));
+        }
+
+        [Test]
+        public void Parse_CustomButtons_SetsButtonTexts()
+        {
+            var vm = ParameterParser.Parse("Hello", new string[] { "Save", "Discard", "Cancel" });
+
+            Assert.That(vm.ButtonUser1Text, Is.EqualTo("Save"));
+            Assert.That(vm.ButtonUser2Text, Is.EqualTo("Discard"));
+            Assert.That(vm.ButtonUser3Text, Is.EqualTo("Cancel"));
+        }
+
+        [Test]
+        public void Parse_CustomButtons_OneButton_SetsOnlyFirst()
+        {
+            var vm = ParameterParser.Parse("Hello", new string[] { "Only" });
+
+            Assert.That(vm.ButtonUser1Text, Is.EqualTo("Only"));
+            Assert.That(vm.ButtonUser2Text, Is.EqualTo("User2"));
+            Assert.That(vm.ButtonUser3Text, Is.EqualTo("User3"));
+        }
+
+        [Test]
+        public void Parse_AutoCloseParameters_SetsAutoClose()
+        {
+            var autoClose = new AutoCloseParameters(10);
+            var vm = ParameterParser.Parse("Hello", autoClose);
+
+            Assert.That(vm.AutoClose, Is.SameAs(autoClose));
+        }
+
+        [Test]
+        public void Parse_DesignParameters_SetsDesign()
+        {
+            var design = new DesignParameters(Color.Red, Color.Blue);
+            var vm = ParameterParser.Parse("Hello", design);
+
+            Assert.That(vm.Design, Is.SameAs(design));
+        }
+
+        [Test]
+        public void Parse_FontAsParameter_CreatesFontParameters()
+        {
+            var font = new Font("Arial", 12);
+            var vm = ParameterParser.Parse("Hello", font);
+
+            Assert.That(vm.FontParameters, Is.Not.Null);
+            Assert.That(vm.FontParameters.HasFont(), Is.True);
+        }
+
+        [Test]
+        public void Parse_AsyncResultCallback_SetsCallback()
+        {
+            AsyncResultCallback callback = (result) => { };
+            var vm = ParameterParser.Parse("Hello", callback);
+
+            Assert.That(vm.Callback, Is.SameAs(callback));
+        }
+
+        #endregion
+
+        #region Multiple Parameters
+
+        [Test]
+        public void Parse_MultipleParameters_SetsAll()
+        {
+            var vm = ParameterParser.Parse("Hello",
+                "Title",
+                InformationBoxButtons.YesNo,
+                InformationBoxIcon.Question,
+                InformationBoxDefaultButton.Button2,
+                InformationBoxStyle.Modern);
+
+            Assert.That(vm.Title, Is.EqualTo("Title"));
+            Assert.That(vm.Buttons, Is.EqualTo(InformationBoxButtons.YesNo));
+            Assert.That(vm.Icon, Is.EqualTo(InformationBoxIcon.Question));
+            Assert.That(vm.DefaultButton, Is.EqualTo(InformationBoxDefaultButton.Button2));
+            Assert.That(vm.Style, Is.EqualTo(InformationBoxStyle.Modern));
+        }
+
+        #endregion
+
+        #region Initialization Parameter
+
+        [Test]
+        public void Parse_FromParametersOnly_SkipsScope()
+        {
+            var vm = ParameterParser.Parse("Hello", InformationBoxInitialization.FromParametersOnly);
+
+            Assert.That(vm.Text, Is.EqualTo("Hello"));
+        }
+
+        #endregion
+
+        #region ParseNamed
+
+        [Test]
+        public void ParseNamed_WithAllDefaults_ReturnsDefaultViewModel()
+        {
+            var vm = ParameterParser.ParseNamed("Hello");
+
+            Assert.That(vm.Text, Is.EqualTo("Hello"));
+            Assert.That(vm.Title, Is.EqualTo(string.Empty));
+            Assert.That(vm.Buttons, Is.EqualTo(InformationBoxButtons.OK));
+            Assert.That(vm.Icon, Is.EqualTo(InformationBoxIcon.None));
+        }
+
+        [Test]
+        public void ParseNamed_WithTitle_SetsTitle()
+        {
+            var vm = ParameterParser.ParseNamed("Hello", title: "My Title");
+
+            Assert.That(vm.Title, Is.EqualTo("My Title"));
+        }
+
+        [Test]
+        public void ParseNamed_WithFont_CreatesFontParameters()
+        {
+            var font = new Font("Arial", 14);
+            var vm = ParameterParser.ParseNamed("Hello", font: font);
+
+            Assert.That(vm.FontParameters, Is.Not.Null);
+            Assert.That(vm.FontParameters.HasFont(), Is.True);
+        }
+
+        [Test]
+        public void ParseNamed_WithCustomIcon_SetsIconType()
+        {
+            var icon = SystemIcons.Warning;
+            var vm = ParameterParser.ParseNamed("Hello", customIcon: icon);
+
+            Assert.That(vm.IconType, Is.EqualTo(IconType.UserDefined));
+            Assert.That(vm.CustomIcon, Is.SameAs(icon));
+        }
+
+        [Test]
+        public void ParseNamed_WithCustomButtons_SetsButtonTexts()
+        {
+            var vm = ParameterParser.ParseNamed("Hello", customButtons: new[] { "A", "B" });
+
+            Assert.That(vm.ButtonUser1Text, Is.EqualTo("A"));
+            Assert.That(vm.ButtonUser2Text, Is.EqualTo("B"));
+        }
+
+        #endregion
+    }
+}

--- a/InfoBoxCore.Tests/ParameterParserTests.cs
+++ b/InfoBoxCore.Tests/ParameterParserTests.cs
@@ -217,7 +217,8 @@ namespace InfoBoxCore.Tests
         [Test]
         public void Parse_CustomButtons_SetsButtonTexts()
         {
-            var vm = ParameterParser.Parse("Hello", new string[] { "Save", "Discard", "Cancel" });
+            // string[] must be boxed as object to avoid params expansion
+            var vm = ParameterParser.Parse("Hello", (object)new string[] { "Save", "Discard", "Cancel" });
 
             Assert.That(vm.ButtonUser1Text, Is.EqualTo("Save"));
             Assert.That(vm.ButtonUser2Text, Is.EqualTo("Discard"));
@@ -227,7 +228,8 @@ namespace InfoBoxCore.Tests
         [Test]
         public void Parse_CustomButtons_OneButton_SetsOnlyFirst()
         {
-            var vm = ParameterParser.Parse("Hello", new string[] { "Only" });
+            // string[] must be boxed as object to avoid params expansion
+            var vm = ParameterParser.Parse("Hello", (object)new string[] { "Only" });
 
             Assert.That(vm.ButtonUser1Text, Is.EqualTo("Only"));
             Assert.That(vm.ButtonUser2Text, Is.EqualTo("User2"));


### PR DESCRIPTION
## Summary

- Extracted 30+ configuration fields and business logic from `InformationBoxForm` (1826 lines) into a new `InformationBoxViewModel` class, reducing the form to a thin UI shell
- Created `ParameterParser` to handle `params object[]` type-detection and named-parameter parsing, returning a populated viewmodel
- Introduced `ITextMeasurer` and `IScreenProvider` interfaces to abstract WinForms dependencies for testability
- Added 132 unit tests covering parameter parsing, viewmodel defaults, button definitions, result mapping, opacity, sounds, checkbox/window style configuration, icon handling, and auto-close logic

## Changes

| File | Purpose |
|------|---------|
| `InformationBoxViewModel.cs` | All configuration state + business logic methods |
| `ParameterParser.cs` | Static `Parse()` and `ParseNamed()` methods |
| `ViewModelTypes.cs` | DTOs: `ButtonDefinition`, `CheckBoxConfiguration`, `WindowStyleConfiguration`, `IconConfiguration`, `AutoCloseTickResult` |
| `ITextMeasurer.cs` / `IScreenProvider.cs` | Abstractions for testability |
| `WinFormsTextMeasurer.cs` / `WinFormsScreenProvider.cs` | Production implementations |
| `InformationBoxForm.cs` | Refactored to use viewmodel (net -1010 lines removed) |
| `InformationBox.cs` | Updated `Show()` to create viewmodel via `ParameterParser` |
| `ParameterParserTests.cs` | 30 tests for parameter parsing |
| `InformationBoxViewModelTests.cs` | 62 tests for viewmodel logic |

## Test plan

- [x] All 140 tests pass (132 InfoBoxCore.Tests + 8 InfoBoxCore.Designer.Tests)
- [x] Build succeeds for both .NET Framework 4.8 and .NET 8/9/10
- [ ] Manual verification via InfoBoxCore.ManualTests to confirm visual behavior is unchanged

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)