### PR TITLE
Pin .NET SDK to 10.0.1xx to fix MSBuild 17 / SDK 10.0.300 mismatch

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `global.json` pinning the .NET SDK to the **10.0.1xx feature band** (with `rollForward: latestPatch`).
- Fixes the Azure DevOps build failures caused by SDK 10.0.300 requiring MSBuild 18+, while the hosted agent's VS 2022 still ships MSBuild 17.14.

## Why
The build started failing with:
> Version 10.0.300 of the .NET SDK requires at least version 18.0.0 of MSBuild. The current available version of MSBuild is 17.14.40.60911.

This affects every `Microsoft.NET.Sdk` / `Microsoft.NET.Sdk.WindowsDesktop` project in the solution (`InfoBoxCore`, `InfoBoxCore.Designer`, `InfoBoxCore.*.Tests`, `InfoBoxCore.ManualTests`). Without this fix, master and every open PR (e.g. [#74](https://github.com/JohannBlais/InformationBox/pull/74)) will be red on Azure Pipelines.

## Test plan
- [ ] Azure Pipelines build for this PR turns green
- [ ] Confirm a 10.0.1xx SDK is actually installed on the hosted agent — if not, fall back to adding a `UseDotNet@2` task in the pipeline definition
- [ ] After merge, rebase [PR #74](https://github.com/JohannBlais/InformationBox/pull/74) via `@dependabot rebase` and confirm it goes green

## Notes
- Local dev environment uses VS 18 / MSBuild 18+ per `CLAUDE.md`, so this only constrains the SDK if 10.0.1xx is installed locally — `rollForward: latestPatch` keeps the build deterministic on the agent.
- This is a temporary workaround. Once the Azure DevOps `windows-latest` image is updated with VS 18 / MSBuild 18, the pin can be relaxed or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)