### PR TITLE
Enable .NET analyzers (AnalysisMode=Recommended)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,4 +15,24 @@
     <LangVersion>10</LangVersion>
   </PropertyGroup>
 
+  <!--
+    .NET code analyzers (CAxxxx rules).
+
+    These properties apply to SDK-style projects (InfoBoxCore.*, the .NET 8/9/10
+    targets). The legacy non-SDK InfoBox.csproj (.NET Framework 4.8) does not
+    pick analyzers up from MSBuild properties alone - it would need a
+    Microsoft.CodeAnalysis.NetAnalyzers PackageReference. We don't bother:
+    the same source is compiled by InfoBoxCore.csproj, so issues are still
+    surfaced when the modern projects build.
+
+    AnalysisLevel=latest pulls the rule set that ships with the SDK in use.
+    AnalysisMode=Recommended enables a curated set of rules at their default
+    severity (warnings, not errors - the build still passes).
+  -->
+  <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>Recommended</AnalysisMode>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Activates the .NET code analyzers (`CAxxxx` rules) on the SDK-style projects via `Directory.Build.props`. Build still passes — analyzers report warnings, not errors.

Settings added:
```xml
<EnableNETAnalyzers>true</EnableNETAnalyzers>
<AnalysisLevel>latest</AnalysisLevel>
<AnalysisMode>Recommended</AnalysisMode>
```

### Why not InfoBox.csproj too?
The legacy `InfoBox.csproj` is a non-SDK project and the `EnableNETAnalyzers` property is a no-op without a `Microsoft.CodeAnalysis.NetAnalyzers` PackageReference. Since the same source files are also compiled by `InfoBoxCore.csproj`, the analyzer findings still surface — no need to duplicate the analyzer setup.

## What this PR surfaces

Azure DevOps build **#262** on this branch is green (236 s, ~30 s overhead from the analyzers). The build now exposes **152 unique warnings** that were previously silent:

| Source | Count | Notes |
|---|---:|---|
| `.NET analyzers (CAxxxx)` | **94 new** | Activated by this PR |
| `SonarCloud (Sxxxx)` | 58 pre-existing | Already on the pipeline, capped at 10 in API summary so they were under-reported before |

### Top new CA rules

| Rule | Count | Subject |
|---|---:|---|
| CA1305 | 48 | Missing `IFormatProvider` on `ToString()` / `Format()` |
| CA1707 | 35 | Underscores in identifiers (mostly test names — idiomatic in tests) |
| CA1805 | 5 | Explicit init to default value |
| CA2263 | 4 | Prefer generic `GetType` overload |
| CA1001 | 1 | `InformationBoxTitleIcon` owns disposable `icon` field but isn't disposable — possible leak |
| CA1309 | 1 | Use ordinal `StringComparison` |

### Top pre-existing S rules (now visible)

| Rule | Count | Subject |
|---|---:|---|
| S3247 | 28 | Type-check-and-cast → pattern matching (perfect with the C# 10 LangVersion bumped in PR #76) |
| S3776 | 9 | High cognitive complexity (the `InformationBoxForm` dispatcher) |
| S107 | 4 | Methods/constructors with > 7 parameters (the `Show` overloads, the form constructor) |
| S1192 | 4 | Repeated magic strings |

### Decision: merge as-is, triage in follow-up PRs

This PR is the *activation*. The 152 warnings represent visible technical debt that will be triaged in dedicated PRs — likely starting with:
1. CA1001 (real bug-shaped finding)
2. S3247 / pattern matching refactor (now unblocked by C# 10)
3. CA1305 mechanical sweep
4. The big `params object[]` dispatcher refactor (covers S107, S3776, several S3247)

## Test plan

- [x] Local build of `InfoBox.csproj` (.NET 4.8) — succeeds, no behavior change
- [x] Azure DevOps CI build #262 — **succeeded** in 236 s, 152 warnings surfaced
- [x] Reviewer skim of the Directory.Build.props diff (1 file changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)