### PR TITLE
Fix CA1001: implement IDisposable on InformationBoxTitleIcon

### DIFF
--- a/InfoBox/Parameters/InformationBoxTitleIcon.cs
+++ b/InfoBox/Parameters/InformationBoxTitleIcon.cs
@@ -6,12 +6,19 @@
 
 namespace InfoBox
 {
+    using System;
     using System.Drawing;
-    
+
     /// <summary>
-    /// Represents the icon for the title bar
+    /// Represents the icon for the title bar.
     /// </summary>
-    public class InformationBoxTitleIcon
+    /// <remarks>
+    /// When constructed with a file name, this instance owns the loaded <see cref="Icon"/>
+    /// and disposes it through <see cref="Dispose()"/>. When constructed with a caller-supplied
+    /// <see cref="Icon"/>, the caller retains ownership; disposing this wrapper will not
+    /// dispose the underlying icon.
+    /// </remarks>
+    public class InformationBoxTitleIcon : IDisposable
     {
         #region Attributes
 
@@ -20,26 +27,43 @@ namespace InfoBox
         /// </summary>
         private readonly Icon icon;
 
+        /// <summary>
+        /// True when this instance loaded the icon and should dispose it; false when
+        /// the caller supplied an existing <see cref="Icon"/>.
+        /// </summary>
+        private readonly bool ownsIcon;
+
+        /// <summary>
+        /// Tracks whether the instance has already been disposed.
+        /// </summary>
+        private bool disposed;
+
         #endregion Attributes
 
         #region Constructors
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InformationBoxTitleIcon"/> class.
+        /// Initializes a new instance of the <see cref="InformationBoxTitleIcon"/> class
+        /// by loading an icon from the specified file. The loaded icon is owned by this
+        /// instance and will be disposed when <see cref="Dispose()"/> is called.
         /// </summary>
         /// <param name="fileName">Name of the file.</param>
         public InformationBoxTitleIcon(string fileName)
         {
             this.icon = new Icon(fileName);
+            this.ownsIcon = true;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InformationBoxTitleIcon"/> class.
+        /// Initializes a new instance of the <see cref="InformationBoxTitleIcon"/> class
+        /// wrapping a caller-supplied icon. The caller retains ownership and is responsible
+        /// for disposing <paramref name="icon"/>.
         /// </summary>
         /// <param name="icon">The title icon.</param>
         public InformationBoxTitleIcon(Icon icon)
         {
             this.icon = icon;
+            this.ownsIcon = false;
         }
 
         #endregion Constructors
@@ -56,5 +80,38 @@ namespace InfoBox
         }
 
         #endregion Properties
+
+        #region IDisposable
+
+        /// <summary>
+        /// Releases the loaded icon if this instance owns it. Has no effect on a
+        /// caller-supplied icon.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the loaded icon if this instance owns it.
+        /// </summary>
+        /// <param name="disposing">True when called from <see cref="Dispose()"/>; false when called from a finalizer.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            if (disposing && this.ownsIcon)
+            {
+                this.icon?.Dispose();
+            }
+
+            this.disposed = true;
+        }
+
+        #endregion IDisposable
     }
 }


### PR DESCRIPTION
## Summary

`InformationBoxTitleIcon` owns a private `Icon` field but was not disposable — flagged by **CA1001** after PR #77 activated the .NET analyzers. The fix makes the class `IDisposable` while respecting the two distinct ownership semantics of its constructors:

| Constructor | Ownership | Dispose behavior |
|---|---|---|
| `InformationBoxTitleIcon(string fileName)` | Wrapper loads the Icon → **owns** it | Disposes the Icon |
| `InformationBoxTitleIcon(Icon icon)` | Caller supplies the Icon → **borrows** it | Leaves the caller's Icon alone |

A private `readonly bool ownsIcon` flag set in each constructor drives the conditional disposal in `Dispose(bool)`. Full Dispose pattern is implemented because the class is public/unsealed; no finalizer is needed since the only field is a managed `Icon` reference (which has its own finalizer).

## Out of scope

`InformationBoxForm` still extracts the inner `Icon` and never disposes the wrapper. The actual leak (when callers create an `InformationBoxTitleIcon(filename)` without `using`) is not closed by this PR — that requires ownership tracking through the form, which would also need to handle the case where `Form.titleIcon` is populated from `InformationBoxScopeParameters.TitleIcon` (a raw `Icon`, no wrapper). Worth a separate, larger PR.

## Test plan

- [x] Local build of `InfoBox.csproj` (.NET 4.8) succeeds
- [x] Azure DevOps CI build **#264 succeeded** on this branch
- [x] CA1001 warning count went from 2 → 0 (verified via Azure DevOps logs API)
- [x] Reviewer skim of the one-file diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)