### PR TITLE
Fix glass gradient bleeding through Standard-style bar with custom color

### DIFF
--- a/InfoBox/Controls/Panel.cs
+++ b/InfoBox/Controls/Panel.cs
@@ -39,6 +39,13 @@ namespace InfoBox.Controls
         /// </summary>
         private int sideBorderWidth = 1;
 
+        /// <summary>
+        /// Whether the glass effect is painted in <see cref="OnPaintBackground"/>.
+        /// Defaults to <c>true</c> to preserve the historical look. Set to <c>false</c>
+        /// for a flat <see cref="System.Windows.Forms.Control.BackColor"/> fill.
+        /// </summary>
+        private bool useGlassEffect = true;
+
         #endregion Attributes
 
         #region Constructor
@@ -138,6 +145,27 @@ namespace InfoBox.Controls
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the glass effect is painted on the
+        /// background. When <c>false</c>, the panel's <see cref="System.Windows.Forms.Control.BackColor"/>
+        /// is rendered as a flat fill (default WinForms paint).
+        /// </summary>
+        /// <value><c>true</c> (default) to paint the glass effect; <c>false</c> for a flat fill.</value>
+        [Category("Appearance"), Description("Defines whether the glass effect is painted on the background"), DefaultValue(true), DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public bool UseGlassEffect
+        {
+            get
+            {
+                return this.useGlassEffect;
+            }
+
+            set
+            {
+                this.useGlassEffect = value;
+                this.Invalidate();
+            }
+        }
+
         #endregion Properties
 
         #region Event Handlers
@@ -148,7 +176,15 @@ namespace InfoBox.Controls
         /// <param name="e">A <see cref="T:System.Windows.Forms.PaintEventArgs"></see> that contains information about the control to paint.</param>
         protected override void OnPaintBackground(PaintEventArgs e)
         {
-            PaintingEngine.PaintGlassEffect(e.Graphics, BackColor, Width, Height);
+            if (this.useGlassEffect)
+            {
+                PaintingEngine.PaintGlassEffect(e.Graphics, BackColor, Width, Height);
+            }
+            else
+            {
+                base.OnPaintBackground(e);
+            }
+
             PaintingEngine.PaintGradientBorders(e.Graphics, this.sideBorderTopColor, this.sideBorderBottomColor, Width, Height, this.sideBorderWidth, this.sideBorder);
         }
 

--- a/InfoBox/Form/InformationBoxForm.cs
+++ b/InfoBox/Form/InformationBoxForm.cs
@@ -885,6 +885,13 @@ namespace InfoBox
                 {
                     barsBackColor = this.design.BarsBackColor;
                     formBackColor = this.design.FormBackColor;
+
+                    // The Controls.Panel paints a glass gradient on top of BackColor by
+                    // default. With a saturated custom BarsBackColor that gradient becomes
+                    // visually obvious (e.g. a "green glass" bar), which clashes with the
+                    // Standard style intent of a flat bar. Disable the glass effect so the
+                    // custom color is rendered as a flat fill.
+                    this.pnlButtons.UseGlassEffect = false;
                 }
 
                 this.pnlButtons.BackColor = barsBackColor;


### PR DESCRIPTION
## Bug

When using \`InformationBoxStyle.Standard\` together with a custom \`DesignParameters.BarsBackColor\`, the button bar rendered with a visible **glass gradient** on top of the chosen color (e.g. a "green glass" bar instead of a flat green one). The Modern style is meant to look glassy; the Standard style is meant to look flat — mixing them in one bar looked broken.

### Reproduction (before the fix)

\`\`\`csharp
InformationBox.Show("Lorem ipsum…",
    InformationBoxButtons.AbortRetryIgnore,
    new DesignParameters(SystemColors.Control, Color.Green));   // bar = green
\`\`\`

→ Bar painted green with a vertical gradient overlay (glass effect), buttons rendered correctly.

## Root cause

\`Controls.Panel.OnPaintBackground\` unconditionally calls \`PaintingEngine.PaintGlassEffect(BackColor)\`. The glass effect paints a Gainsboro background, then overlays three vertical gradients in different alphas of \`BackColor\`.

With the historical default of \`BackColor = SystemColors.Control\` (light gray), the gradient is nearly invisible (gray on gainsboro). With a saturated custom color the gradient becomes obvious.

## Fix

1. **New \`UseGlassEffect\` bool property on \`Controls.Panel\`** (default \`true\`, so every other usage of the type is unchanged). When \`false\`, \`OnPaintBackground\` delegates to \`base.OnPaintBackground\` for a flat fill and skips the glass step. The side-border step still runs.

2. **\`InformationBoxForm.SetWindowStyle\`, Standard branch**: set \`pnlButtons.UseGlassEffect = false\` **only when \`this.design\` is non-null**. Conservative scope — the default Standard look (no design) keeps the historical subtle glass behavior; only the custom-design scenario flips to flat rendering, which is precisely the bug scenario.

Modern style is unaffected (\`UseGlassEffect\` stays \`true\` there).

## Test plan

- [x] Local build of \`InfoBox.csproj\` (.NET 4.8) — succeeds
- [x] All 32 \`InfoBoxCore.Tests\` pass — no regression
- [x] Manual smoke test: \`InformationBox.Show("...", new DesignParameters(..., Color.Green))\` in \`InfoBoxCore.ManualTests\` → bar should be flat green, buttons unchanged
- [x] Confirm Standard without design + Modern (with and without design) are visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)