### PR TITLE
Designer: skip DesignParameters when Custom colors is checked but no color picked

### DIFF
--- a/InfoBox.Designer/InformationBoxDesigner.cs
+++ b/InfoBox.Designer/InformationBoxDesigner.cs
@@ -558,10 +558,24 @@ namespace InfoBox.Designer
         /// <summary>
         /// Gets the design.
         /// </summary>
-        /// <returns>The design.</returns>
+        /// <returns>The design parameters built from the user's color choices, or null when
+        /// no design override should be applied.</returns>
+        /// <remarks>
+        /// Returns null when "Custom colors" is unchecked, but also when it is checked
+        /// without any actual color having been picked. The two color fields start as
+        /// <see cref="Color.Empty"/>, and forwarding empty colors to
+        /// <see cref="DesignParameters"/> breaks the Modern style rendering (the form's
+        /// background becomes effectively transparent) and produces misleading
+        /// <c>Color.FromArgb(0,0,0)</c> output in the "Generate code" preview.
+        /// </remarks>
         private DesignParameters GetDesign()
         {
             if (!this.chbCustomColors.Checked)
+            {
+                return null;
+            }
+
+            if (this.formColor.IsEmpty && this.barsColor.IsEmpty)
             {
                 return null;
             }


### PR DESCRIPTION
## Bug

In the InformationBox Designer, ticking the **Custom colors** checkbox without actually picking a Bars or Form color breaks the Modern style preview:

| Before (broken Modern when Custom colors is checked without selection) | After (no color selected = same as Custom colors unchecked) |
|---|---|
| Form background becomes transparent / weird | Normal Modern rendering |

The same issue silently corrupts the **Generate code** output: the preview generates \`Color.FromArgb(0, 0, 0)\` calls based on the empty color fields, which the user might copy-paste thinking they reflect their selection.

## Root cause

\`InformationBoxDesigner.cs\` declares the two color fields as:

\`\`\`csharp
private Color barsColor = Color.Empty;
private Color formColor = Color.Empty;
\`\`\`

\`GetDesign()\` returned \`null\` only when the checkbox was unchecked:

\`\`\`csharp
private DesignParameters GetDesign()
{
    if (!this.chbCustomColors.Checked) { return null; }
    return new DesignParameters(this.formColor, this.barsColor);
}
\`\`\`

As soon as the user ticked the checkbox, even without picking colors, a \`DesignParameters(Color.Empty, Color.Empty)\` was forwarded to the form. \`Color.Empty\` has \`A=0\` (fully transparent), so applying it as \`pnlButtons.BackColor\` / \`pnlForm.BackColor\` produced the broken render.

## Fix

\`GetDesign()\` now also returns \`null\` when the checkbox is ticked but both color fields are still \`Color.Empty\`. Single-site change heals both the Show preview and the Generate code output, since both consume the same \`GetDesign()\` result.

## Out of scope

The partial case (user picks Bars but not Form, or vice versa) is left as-is: the unset color still ships as \`Color.Empty\` to \`DesignParameters\`. A future improvement could fall back to style-specific defaults for the missing color — but that requires knowing the active \`InformationBoxStyle\` at design-build time, and the right default differs (Modern wants Black/Silver, Standard wants \`SystemColors.Control\`).

## Test plan

- [x] Local build of \`InfoBoxCore.Designer\` succeeds with no new warnings
- [x] Manual smoke test in the designer:
  - Tick Custom colors, leave Bars / Form empty, click Show → Modern preview should render normally (no transparent panels)
  - Same scenario + click Generate code → output should NOT contain a \`design: new DesignParameters(...)\` argument
  - Tick Custom colors, pick both Bars and Form colors → preview applies them as before
  - Untick Custom colors → preview defaults to plain Modern look

🤖 Generated with [Claude Code](https://claude.com/claude-code)