### PR TITLE
Clean up CA1805, CA2263, S3247 analyzer warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -41,6 +41,12 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggesti
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
 
+# CA2263: prefers the generic Enum.GetValues<TEnum>() overload, which only exists on
+# .NET 5+. The shared source is also compiled into the .NET Framework 4.8 projects
+# (InfoBox, InfoBox.Designer), where only the non-generic Enum.GetValues(Type) exists -
+# so the suggested fix cannot be applied without breaking the dual-build. Suppressed.
+dotnet_diagnostic.CA2263.severity = none
+
 # Test files: relax rules that conflict with established test-writing idioms.
 [**/*Tests.cs]
 

--- a/InfoBox.Designer/InformationBoxDesigner.cs
+++ b/InfoBox.Designer/InformationBoxDesigner.cs
@@ -34,7 +34,7 @@ namespace InfoBox.Designer
         /// <summary>
         /// Font for the message text
         /// </summary>
-        private Font messageFont = null;
+        private Font messageFont;
 
         /// <summary>
         /// Color for the message text
@@ -44,7 +44,7 @@ namespace InfoBox.Designer
         /// <summary>
         /// Text editor form instance
         /// </summary>
-        private TextEditorForm textEditorForm = null;
+        private TextEditorForm textEditorForm;
 
         #endregion Attributes
 

--- a/InfoBox.Designer/TextEditorForm.cs
+++ b/InfoBox.Designer/TextEditorForm.cs
@@ -16,7 +16,7 @@ namespace InfoBox.Designer
     public partial class TextEditorForm : Form
     {
         private readonly InformationBoxDesigner parentDesigner;
-        private bool isUpdating = false;
+        private bool isUpdating;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextEditorForm"/> class.

--- a/InfoBox/Context/InformationBoxScope.cs
+++ b/InfoBox/Context/InformationBoxScope.cs
@@ -24,7 +24,7 @@ namespace InfoBox
         /// <summary>
         /// Contains the parameters defined within the scope
         /// </summary>
-        private readonly InformationBoxScopeParameters definedParameters = new InformationBoxScopeParameters();
+        private readonly InformationBoxScopeParameters definedParameters;
 
         #endregion Attributes
 

--- a/InfoBox/Form/InformationBoxForm.cs
+++ b/InfoBox/Form/InformationBoxForm.cs
@@ -127,7 +127,7 @@ namespace InfoBox
         /// <summary>
         /// Contains a value defining whether displaying the checkbox or not
         /// </summary>
-        private InformationBoxCheckBox checkBox = 0;
+        private InformationBoxCheckBox checkBox;
 
         /// <summary>
         /// Contains the style of the box
@@ -1573,9 +1573,9 @@ namespace InfoBox
         /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
         private void Button_Click(object sender, EventArgs e)
         {
-            if (sender is Control)
+            if (sender is Control control)
             {
-                this.HandleButton((Control)sender);
+                this.HandleButton(control);
             }
         }
 
@@ -1758,28 +1758,26 @@ namespace InfoBox
                 {
                     Regex extractLabel = new Regex(@".*?\(\d+\)");
 
-                    if (buttonToUpdate is System.Windows.Forms.Button)
+                    if (buttonToUpdate is System.Windows.Forms.Button winFormsButton)
                     {
-                        System.Windows.Forms.Button button = (System.Windows.Forms.Button)buttonToUpdate;
-                        if (extractLabel.IsMatch(button.Text))
+                        if (extractLabel.IsMatch(winFormsButton.Text))
                         {
-                            button.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", button.Text.Substring(0, button.Text.LastIndexOf(" (", StringComparison.OrdinalIgnoreCase)), this.autoClose.Seconds - this.elapsedTime);
+                            winFormsButton.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", winFormsButton.Text.Substring(0, winFormsButton.Text.LastIndexOf(" (", StringComparison.OrdinalIgnoreCase)), this.autoClose.Seconds - this.elapsedTime);
                         }
                         else
                         {
-                            button.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", button.Text, this.autoClose.Seconds - this.elapsedTime);
+                            winFormsButton.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", winFormsButton.Text, this.autoClose.Seconds - this.elapsedTime);
                         }
                     }
-                    else if (buttonToUpdate is Controls.Button)
+                    else if (buttonToUpdate is Controls.Button glassButton)
                     {
-                        Controls.Button button = (Controls.Button)buttonToUpdate;
-                        if (extractLabel.IsMatch(button.Text))
+                        if (extractLabel.IsMatch(glassButton.Text))
                         {
-                            button.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", button.Text.Substring(0, button.Text.LastIndexOf(" (", StringComparison.OrdinalIgnoreCase)), this.autoClose.Seconds - this.elapsedTime);
+                            glassButton.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", glassButton.Text.Substring(0, glassButton.Text.LastIndexOf(" (", StringComparison.OrdinalIgnoreCase)), this.autoClose.Seconds - this.elapsedTime);
                         }
                         else
                         {
-                            button.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", button.Text, this.autoClose.Seconds - this.elapsedTime);
+                            glassButton.Text = String.Format(CultureInfo.InvariantCulture, "{0} ({1})", glassButton.Text, this.autoClose.Seconds - this.elapsedTime);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Mechanical analyzer cleanup bundling three small rule families. No behavior change; both .NET Framework 4.8 projects build and all 84 tests pass.

### CA1805 — redundant default-value field initializers (5)

| File | Before | After |
|---|---|---|
| `InformationBoxForm.cs` | `checkBox = 0` | `checkBox;` |
| `InformationBoxScope.cs` | `definedParameters = new InformationBoxScopeParameters()` | `definedParameters;` |
| `InformationBoxDesigner.cs` | `messageFont = null` | `messageFont;` |
| `InformationBoxDesigner.cs` | `textEditorForm = null` | `textEditorForm;` |
| `TextEditorForm.cs` | `isUpdating = false` | `isUpdating;` |

- `checkBox`: the `[Flags] InformationBoxCheckBox` enum has no zero member, so `0` means "no flags" — identical to the field default.
- `definedParameters`: `InformationBoxScopeParameters` is a **struct**, so `new()` equals `default`. The readonly field keeps the same value without the initializer (the parameterless ctor leaves it at the struct default, exactly as before).

### S3247 — type-check-and-cast → pattern matching (3, all in `InformationBoxForm.cs`)

- `if (sender is Control) { … (Control)sender … }` → `if (sender is Control control)`
- The two autoclose button branches: `is X` followed by an explicit cast → `is X local`. Distinct names (`winFormsButton` / `glassButton`) are used on purpose: a pattern variable declared in an `if` condition leaks into the enclosing scope, so reusing `button` in the `else if` would be a CS0136 collision.

Enabled by the C# 10 LangVersion from #76 — pattern matching compiles fine on .NET Framework 4.8.

### CA2263 — suppressed, not fixed (dual-build constraint)

CA2263 suggests the generic `Enum.GetValues<TEnum>()` overload over `Enum.GetValues(typeof(T))`. That overload **only exists on .NET 5+**, but the designer source is also compiled into `InfoBox.Designer` targeting **.NET Framework 4.8**, where only the non-generic overload is available. The suggested fix is therefore incompatible with the dual-build, so the rule is turned off in `.editorconfig` with an explanatory comment rather than applied.

## Test plan

- [x] `msbuild InfoBox.csproj` (.NET 4.8) — builds
- [x] `msbuild InfoBox.Designer.csproj` (.NET 4.8) — builds
- [x] `dotnet test InfoBoxCore.Tests` — 84 / 84 pass
- [ ] Azure DevOps CI build
- [ ] Reviewer skim of the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)