### PR TITLE
Add IFormatProvider to designer string formatting (CA1305)

### DIFF
--- a/InfoBox.Designer/CodeGeneration/CSharpGenerator.cs
+++ b/InfoBox.Designer/CodeGeneration/CSharpGenerator.cs
@@ -78,69 +78,69 @@ namespace InfoBox.Designer.CodeGeneration
             StringBuilder codeBuilder = new StringBuilder();
             if (checkState == 0)
             {
-                codeBuilder.AppendFormat("InformationBox.Show(\"{0}\", ", text.Replace(Environment.NewLine, "\\n"));
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBox.Show(\"{0}\", ", text.Replace(Environment.NewLine, "\\n"));
             }
             else
             {
                 codeBuilder.Append("CheckState doNotShowState = CheckState.Indeterminate;");
                 codeBuilder.Append(Environment.NewLine);
-                codeBuilder.AppendFormat("InformationBox.Show(\"{0}\", out doNotShowState, ", text.Replace(Environment.NewLine, "\\n"));
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBox.Show(\"{0}\", out doNotShowState, ", text.Replace(Environment.NewLine, "\\n"));
             }
 
             if (!String.IsNullOrEmpty(title))
             {
-                codeBuilder.AppendFormat("title: \"{0}\", ", title);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "title: \"{0}\", ", title);
             }
 
             if (buttons != InformationBoxButtons.OK)
             {
-                codeBuilder.AppendFormat("buttons: InformationBoxButtons.{0}, ", buttons);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "buttons: InformationBoxButtons.{0}, ", buttons);
             }
 
             if (buttons == InformationBoxButtons.OKCancelUser1 ||
                 buttons == InformationBoxButtons.User1User2 ||
                 buttons == InformationBoxButtons.YesNoUser1)
             {
-                codeBuilder.AppendFormat("customButtons: new string[] {{ \"{0}\", \"{1}\" }}, ", button1Text, button2Text);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "customButtons: new string[] {{ \"{0}\", \"{1}\" }}, ", button1Text, button2Text);
             }
             else if (buttons == InformationBoxButtons.User1User2User3)
             {
-                codeBuilder.AppendFormat("customButtons: new string[] {{ \"{0}\", \"{1}\", \"{2}\" }}, ", button1Text, button2Text, button3Text);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "customButtons: new string[] {{ \"{0}\", \"{1}\", \"{2}\" }}, ", button1Text, button2Text, button3Text);
             }
 
             if (icon != InformationBoxIcon.None)
             {
-                codeBuilder.AppendFormat("icon: InformationBoxIcon.{0}, ", icon);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "icon: InformationBoxIcon.{0}, ", icon);
             }
 
             if (!String.IsNullOrEmpty(iconFileName))
             {
-                codeBuilder.AppendFormat("customIcon: new System.Drawing.Icon(@\"{0}\"), ", iconFileName);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "customIcon: new System.Drawing.Icon(@\"{0}\"), ", iconFileName);
             }
 
             if (defaultButton != InformationBoxDefaultButton.Button1)
             {
-                codeBuilder.AppendFormat("defaultButton: InformationBoxDefaultButton.{0}, ", defaultButton);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "defaultButton: InformationBoxDefaultButton.{0}, ", defaultButton);
             }
 
             if (buttonsLayout != InformationBoxButtonsLayout.GroupMiddle)
             {
-                codeBuilder.AppendFormat("buttonsLayout: InformationBoxButtonsLayout.{0}, ", buttonsLayout);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "buttonsLayout: InformationBoxButtonsLayout.{0}, ", buttonsLayout);
             }
 
             if (autoSize != InformationBoxAutoSizeMode.None)
             {
-                codeBuilder.AppendFormat("autoSizeMode: InformationBoxAutoSizeMode.{0}, ", autoSize);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "autoSizeMode: InformationBoxAutoSizeMode.{0}, ", autoSize);
             }
 
             if (sound != InformationBoxSound.Default)
             {
-                codeBuilder.AppendFormat("sound: InformationBoxSound.{0}, ", sound);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "sound: InformationBoxSound.{0}, ", sound);
             }
 
             if (position != InformationBoxPosition.CenterOnParent)
             {
-                codeBuilder.AppendFormat("position: InformationBoxPosition.{0}, ", position);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "position: InformationBoxPosition.{0}, ", position);
             }
 
             if (showHelp)
@@ -150,17 +150,17 @@ namespace InfoBox.Designer.CodeGeneration
 
             if (!String.IsNullOrEmpty(helpFile))
             {
-                codeBuilder.AppendFormat("helpFile: @\"{0}\", ", helpFile);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "helpFile: @\"{0}\", ", helpFile);
             }
 
             if (navigator != 0)
             {
-                codeBuilder.AppendFormat("helpNavigator: HelpNavigator.{0}, ", navigator);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "helpNavigator: HelpNavigator.{0}, ", navigator);
             }
 
             if (!String.IsNullOrEmpty(helpTopic))
             {
-                codeBuilder.AppendFormat("helpTopic: \"{0}\", ", helpTopic);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "helpTopic: \"{0}\", ", helpTopic);
             }
 
             if (checkState != 0)
@@ -181,17 +181,17 @@ namespace InfoBox.Designer.CodeGeneration
 
             if (doNotShowAgainText != null)
             {
-                codeBuilder.AppendFormat("doNotShowAgainText: \"{0}\", ", doNotShowAgainText);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "doNotShowAgainText: \"{0}\", ", doNotShowAgainText);
             }
 
             if (style != InformationBoxStyle.Standard)
             {
-                codeBuilder.AppendFormat("style: InformationBoxStyle.{0}, ", style);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "style: InformationBoxStyle.{0}, ", style);
             }
 
             if (order != InformationBoxOrder.Default)
             {
-                codeBuilder.AppendFormat("order: InformationBoxOrder.{0}, ", order);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "order: InformationBoxOrder.{0}, ", order);
             }
 
             if (useAutoClose)
@@ -206,15 +206,15 @@ namespace InfoBox.Designer.CodeGeneration
                 {
                     if (autoClose.Mode == AutoCloseDefinedParameters.Button)
                     {
-                        codeBuilder.AppendFormat("autoClose: new AutoCloseParameters({0}, InformationBoxDefaultButton.{1}), ", autoClose.Seconds, autoClose.DefaultButton);
+                        codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "autoClose: new AutoCloseParameters({0}, InformationBoxDefaultButton.{1}), ", autoClose.Seconds, autoClose.DefaultButton);
                     }
                     else if (autoClose.Mode == AutoCloseDefinedParameters.Result)
                     {
-                        codeBuilder.AppendFormat("autoClose: new AutoCloseParameters({0}, InformationBoxResult.{1}), ", autoClose.Seconds, autoClose.Result);
+                        codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "autoClose: new AutoCloseParameters({0}, InformationBoxResult.{1}), ", autoClose.Seconds, autoClose.Result);
                     }
                     else
                     {
-                        codeBuilder.AppendFormat("autoClose: new AutoCloseParameters({0}), ", autoClose.Seconds);
+                        codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "autoClose: new AutoCloseParameters({0}), ", autoClose.Seconds);
                     }
                 }
             }
@@ -266,7 +266,7 @@ namespace InfoBox.Designer.CodeGeneration
 
             if (opacity != InformationBoxOpacity.NoFade)
             {
-                codeBuilder.AppendFormat("opacity: InformationBoxOpacity.{0}, ", opacity);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "opacity: InformationBoxOpacity.{0}, ", opacity);
             }
 
             codeBuilder[codeBuilder.Length - 2] = ')';

--- a/InfoBox.Designer/CodeGeneration/VbNetGenerator.cs
+++ b/InfoBox.Designer/CodeGeneration/VbNetGenerator.cs
@@ -46,69 +46,69 @@ namespace InfoBox.Designer.CodeGeneration
             StringBuilder codeBuilder = new StringBuilder();
             if (checkState == 0)
             {
-                codeBuilder.AppendFormat("InformationBox.Show(\"{0}\", ", text.Replace(Environment.NewLine, "\\n"));
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBox.Show(\"{0}\", ", text.Replace(Environment.NewLine, "\\n"));
             }
             else
             {
                 codeBuilder.Append("Dim doNotShowState as CheckState = CheckState.Indeterminate");
                 codeBuilder.Append(Environment.NewLine);
-                codeBuilder.AppendFormat("InformationBox.Show(\"{0}\", doNotShowState, ", text.Replace(Environment.NewLine, "\\n"));
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBox.Show(\"{0}\", doNotShowState, ", text.Replace(Environment.NewLine, "\\n"));
             }
 
             if (!String.IsNullOrEmpty(helpFile) || !String.IsNullOrEmpty(title))
             {
-                codeBuilder.AppendFormat("\"{0}\", ", title);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\", ", title);
             }
 
             if (buttons != InformationBoxButtons.OK)
             {
-                codeBuilder.AppendFormat("InformationBoxButtons.{0}, ", buttons);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxButtons.{0}, ", buttons);
             }
 
             if (buttons == InformationBoxButtons.OKCancelUser1 ||
                 buttons == InformationBoxButtons.User1User2 ||
                 buttons == InformationBoxButtons.YesNoUser1)
             {
-                codeBuilder.AppendFormat("New String() {{ \"{0}\", \"{1}\" }}, ", button1Text, button2Text);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "New String() {{ \"{0}\", \"{1}\" }}, ", button1Text, button2Text);
             }
             else if (buttons == InformationBoxButtons.User1User2User3)
             {
-                codeBuilder.AppendFormat("New String() {{ \"{0}\", \"{1}\", \"{2}\" }}, ", button1Text, button2Text, button3Text);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "New String() {{ \"{0}\", \"{1}\", \"{2}\" }}, ", button1Text, button2Text, button3Text);
             }
 
             if (icon != InformationBoxIcon.None)
             {
-                codeBuilder.AppendFormat("InformationBoxIcon.{0}, ", icon);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxIcon.{0}, ", icon);
             }
 
             if (!String.IsNullOrEmpty(iconFileName))
             {
-                codeBuilder.AppendFormat("New System.Drawing.Icon(@\"{0}\"), ", iconFileName);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "New System.Drawing.Icon(@\"{0}\"), ", iconFileName);
             }
 
             if (defaultButton != InformationBoxDefaultButton.Button1)
             {
-                codeBuilder.AppendFormat("InformationBoxDefaultButton.{0}, ", defaultButton);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxDefaultButton.{0}, ", defaultButton);
             }
 
             if (buttonsLayout != InformationBoxButtonsLayout.GroupMiddle)
             {
-                codeBuilder.AppendFormat("InformationBoxButtonsLayout.{0}, ", buttonsLayout);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxButtonsLayout.{0}, ", buttonsLayout);
             }
 
             if (autoSize != InformationBoxAutoSizeMode.None)
             {
-                codeBuilder.AppendFormat("InformationBoxAutoSizeMode.{0}, ", autoSize);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxAutoSizeMode.{0}, ", autoSize);
             }
 
             if (sound != InformationBoxSound.Default)
             {
-                codeBuilder.AppendFormat("InformationBoxSound.{0}, ", sound);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxSound.{0}, ", sound);
             }
 
             if (position != InformationBoxPosition.CenterOnParent)
             {
-                codeBuilder.AppendFormat("InformationBoxPosition.{0}, ", position);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxPosition.{0}, ", position);
             }
 
             if (showHelp)
@@ -118,17 +118,17 @@ namespace InfoBox.Designer.CodeGeneration
 
             if (!String.IsNullOrEmpty(helpFile))
             {
-                codeBuilder.AppendFormat("\"{0}\", ", helpFile);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\", ", helpFile);
             }
 
             if (navigator != 0)
             {
-                codeBuilder.AppendFormat("HelpNavigator.{0}, ", navigator);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "HelpNavigator.{0}, ", navigator);
             }
 
             if (!String.IsNullOrEmpty(helpTopic))
             {
-                codeBuilder.AppendFormat("\"{0}\", ", helpTopic);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\", ", helpTopic);
             }
 
             if (checkState != 0)
@@ -149,17 +149,17 @@ namespace InfoBox.Designer.CodeGeneration
 
             if (doNotShowAgainText != null)
             {
-                codeBuilder.AppendFormat("\"{0}\", ", doNotShowAgainText);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\", ", doNotShowAgainText);
             }
 
             if (style != InformationBoxStyle.Standard)
             {
-                codeBuilder.AppendFormat("InformationBoxStyle.{0}, ", style);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxStyle.{0}, ", style);
             }
 
             if (order != InformationBoxOrder.Default)
             {
-                codeBuilder.AppendFormat("InformationBoxOrder.{0}, ", order);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxOrder.{0}, ", order);
             }
 
             if (useAutoClose)
@@ -174,15 +174,15 @@ namespace InfoBox.Designer.CodeGeneration
                 {
                     if (autoClose.Mode == AutoCloseDefinedParameters.Button)
                     {
-                        codeBuilder.AppendFormat("New AutoCloseParameters({0}, InformationBoxDefaultButton.{1}), ", autoClose.Seconds, autoClose.DefaultButton);
+                        codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "New AutoCloseParameters({0}, InformationBoxDefaultButton.{1}), ", autoClose.Seconds, autoClose.DefaultButton);
                     }
                     else if (autoClose.Mode == AutoCloseDefinedParameters.Result)
                     {
-                        codeBuilder.AppendFormat("New AutoCloseParameters({0}, InformationBoxResult.{1}), ", autoClose.Seconds, autoClose.Result);
+                        codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "New AutoCloseParameters({0}, InformationBoxResult.{1}), ", autoClose.Seconds, autoClose.Result);
                     }
                     else
                     {
-                        codeBuilder.AppendFormat("New AutoCloseParameters({0}), ", autoClose.Seconds);
+                        codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "New AutoCloseParameters({0}), ", autoClose.Seconds);
                     }
                 }
             }
@@ -234,7 +234,7 @@ namespace InfoBox.Designer.CodeGeneration
 
             if (opacity != InformationBoxOpacity.NoFade)
             {
-                codeBuilder.AppendFormat("InformationBoxOpacity.{0}, ", opacity);
+                codeBuilder.AppendFormat(CultureInfo.InvariantCulture, "InformationBoxOpacity.{0}, ", opacity);
             }
 
             codeBuilder[codeBuilder.Length - 2] = ')';

--- a/InfoBox.Designer/InformationBoxDesigner.cs
+++ b/InfoBox.Designer/InformationBoxDesigner.cs
@@ -860,7 +860,7 @@ namespace InfoBox.Designer
 
             Font selected = this.dlgFont.Font;
 
-            this.txbMessageFont.Text = string.Format("{0}, {1}pt", selected.Name, selected.Size);
+            this.txbMessageFont.Text = string.Format(CultureInfo.CurrentCulture, "{0}, {1}pt", selected.Name, selected.Size);
             this.messageFont = selected;
         }
 
@@ -886,7 +886,7 @@ namespace InfoBox.Designer
 
             Color selected = this.dlgColor.Color;
 
-            this.txbMessageColor.Text = string.Format("R={0}, G={1}, B={2}", selected.R, selected.G, selected.B);
+            this.txbMessageColor.Text = string.Format(CultureInfo.CurrentCulture, "R={0}, G={1}, B={2}", selected.R, selected.G, selected.B);
             this.lblFontColor.BackColor = selected;
             this.messageFontColor = selected;
         }


### PR DESCRIPTION
## Summary

Resolves all **48 CA1305** warnings (missing `IFormatProvider`). They were all in the designer source — the main library was already clean (its autoclose formatting already used `CultureInfo.InvariantCulture`).

### Code generators — `InvariantCulture` (46 calls)

`CSharpGenerator.cs` and `VbNetGenerator.cs` each had 23 `codeBuilder.AppendFormat("…")` calls without a provider. All now pass `CultureInfo.InvariantCulture`, matching the convention already in place for the `DesignParameters` / `FontParameters` / `titleIcon` lines in the same files.

This is **correctness, not just lint**: the generators emit C#/VB source code. Numbers in that output (Color RGB components, AutoClose seconds, font size) must use `.` as the decimal separator regardless of the developer's locale — otherwise the generated code could be malformed under, e.g., a French locale (`9,5F`).

### Designer UI — `CurrentCulture` (2 calls)

The two `string.Format` calls in `InformationBoxDesigner.cs` that build the font and color **display labels** (`txbMessageFont` = "Segoe UI, 9pt", `txbMessageColor` = "R=255, G=0, B=0") use `CultureInfo.CurrentCulture` — these are user-facing display strings shown in the designer, not machine-readable output, so locale-aware formatting is the semantically-correct CA1305 resolution.

## Dual-build note

`CultureInfo` and the `IFormatProvider` overloads of `AppendFormat` / `string.Format` exist on .NET Framework 4.8, so this compiles on both the legacy and modern designer projects.

## Test plan

- [x] `msbuild InfoBox.Designer.csproj` (.NET 4.8) — builds, 0 CA1305
- [x] `dotnet build InfoBoxCore.Designer` (net8/9/10) — builds, 0 CA1305
- [x] `dotnet test InfoBoxCore.Designer.Tests` — **8 / 8 pass**. These compile the generated code via Roslyn, confirming the emitted output is byte-for-byte valid (the sweep didn't change behavior).
- [ ] Azure DevOps CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)