### PR TITLE
Conform InformationBoxScope to the IDisposable pattern (S3881)

### DIFF
--- a/InfoBox/Context/InformationBoxScope.cs
+++ b/InfoBox/Context/InformationBoxScope.cs
@@ -26,6 +26,12 @@ namespace InfoBox
         /// </summary>
         private readonly InformationBoxScopeParameters definedParameters;
 
+        /// <summary>
+        /// Tracks whether the scope has already been disposed, to avoid popping the
+        /// stack more than once.
+        /// </summary>
+        private bool disposed;
+
         #endregion Attributes
 
         #region Constructors
@@ -117,28 +123,34 @@ namespace InfoBox
         #region Dispose
 
         /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting resources.
         /// </summary>
         public void Dispose()
         {
-            scopesStack.Pop();
-
             this.Dispose(true);
             GC.SuppressFinalize(this);
         }
 
         /// <summary>
-        /// Releases unmanaged and - optionally - managed resources
+        /// Releases the resources held by the scope. When <paramref name="disposing"/> is
+        /// <c>true</c>, removes this scope from the active scope stack.
         /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        /// <param name="disposing"><c>true</c> to release managed resources; <c>false</c> when called from a finalizer.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (this.disposed)
             {
-                // Releases unmanaged resources
+                return;
             }
 
-            // Releases managed resources
+            if (disposing)
+            {
+                // The scope stack only holds managed references, so it is only touched
+                // when disposing deterministically (never from a finalizer).
+                scopesStack.Pop();
+            }
+
+            this.disposed = true;
         }
 
         #endregion Dispose

--- a/InfoBoxCore.Tests/InformationBoxScopeTests.cs
+++ b/InfoBoxCore.Tests/InformationBoxScopeTests.cs
@@ -1,0 +1,86 @@
+using InfoBox;
+using NUnit.Framework;
+
+namespace InfoBoxCore.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="InformationBoxScope"/>'s push/pop lifecycle and its
+    /// IDisposable implementation - in particular that disposing is idempotent and
+    /// does not pop an unrelated scope off the shared stack.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="InformationBoxScope.Current"/> is backed by a process-wide static
+    /// stack, so every test captures the baseline scope on entry and asserts the stack
+    /// is restored to it, keeping the tests independent of execution order.
+    /// </remarks>
+    [TestFixture]
+    public class InformationBoxScopeTests
+    {
+        [Test]
+        public void Constructor_PushesScopeAsCurrent()
+        {
+            InformationBoxScope baseline = InformationBoxScope.Current;
+
+            using (InformationBoxScope scope = new InformationBoxScope())
+            {
+                Assert.That(InformationBoxScope.Current, Is.SameAs(scope));
+            }
+
+            Assert.That(InformationBoxScope.Current, Is.SameAs(baseline));
+        }
+
+        [Test]
+        public void Dispose_PopsScopeRestoringTheParent()
+        {
+            InformationBoxScope baseline = InformationBoxScope.Current;
+
+            InformationBoxScope outer = new InformationBoxScope();
+            InformationBoxScope inner = new InformationBoxScope();
+            Assert.That(InformationBoxScope.Current, Is.SameAs(inner));
+
+            inner.Dispose();
+            Assert.That(InformationBoxScope.Current, Is.SameAs(outer));
+
+            outer.Dispose();
+            Assert.That(InformationBoxScope.Current, Is.SameAs(baseline));
+        }
+
+        [Test]
+        public void Dispose_CalledTwice_DoesNotPopAnExtraScope()
+        {
+            InformationBoxScope outer = new InformationBoxScope();
+            InformationBoxScope inner = new InformationBoxScope();
+
+            inner.Dispose();
+            Assert.That(InformationBoxScope.Current, Is.SameAs(outer));
+
+            // Second dispose must be a no-op; without the disposed guard this would pop
+            // the outer scope (or throw on an empty stack).
+            inner.Dispose();
+            Assert.That(InformationBoxScope.Current, Is.SameAs(outer), "a second Dispose() must not pop the parent scope");
+
+            outer.Dispose();
+        }
+
+        [Test]
+        public void NestedScopes_DisposeInLifoOrder_RestoreCorrectly()
+        {
+            InformationBoxScope baseline = InformationBoxScope.Current;
+
+            InformationBoxScope first = new InformationBoxScope();
+            InformationBoxScope second = new InformationBoxScope();
+            InformationBoxScope third = new InformationBoxScope();
+
+            Assert.That(InformationBoxScope.Current, Is.SameAs(third));
+
+            third.Dispose();
+            Assert.That(InformationBoxScope.Current, Is.SameAs(second));
+
+            second.Dispose();
+            Assert.That(InformationBoxScope.Current, Is.SameAs(first));
+
+            first.Dispose();
+            Assert.That(InformationBoxScope.Current, Is.SameAs(baseline));
+        }
+    }
+}


### PR DESCRIPTION
## Bug + cleanup

`InformationBoxScope` implemented `IDisposable` incorrectly (SonarCloud **S3881**), and the incorrect shape hid a real latent bug.

### Before

\`\`\`csharp
public void Dispose()
{
    scopesStack.Pop();          // cleanup work in the public Dispose()
    this.Dispose(true);
    GC.SuppressFinalize(this);
}

protected virtual void Dispose(bool disposing) { /* empty */ }
\`\`\`

Two problems:
1. **S3881**: the public `Dispose()` performs cleanup (`scopesStack.Pop()`) instead of delegating everything to `Dispose(bool)`.
2. **Latent double-dispose bug**: there was no `disposed` guard, so calling `Dispose()` twice (or a `using` over an already-disposed scope) popped a *second*, unrelated scope off the shared stack — or threw `InvalidOperationException` on an empty stack.

### After

\`\`\`csharp
public void Dispose()
{
    this.Dispose(true);
    GC.SuppressFinalize(this);
}

protected virtual void Dispose(bool disposing)
{
    if (this.disposed) return;
    if (disposing)
    {
        scopesStack.Pop();      // managed-only state -> guarded by `disposing`
    }
    this.disposed = true;
}
\`\`\`

- All cleanup is in `Dispose(bool)`; the public `Dispose()` is just the two canonical calls.
- `Pop()` is under `if (disposing)` because the stack holds only managed references (never touched from a finalizer).
- The `disposed` guard makes a repeated `Dispose()` a safe no-op.

## Tests

New `InformationBoxScopeTests` (4 tests) — the type had **zero** coverage before:
- `Constructor_PushesScopeAsCurrent`
- `Dispose_PopsScopeRestoringTheParent`
- `Dispose_CalledTwice_DoesNotPopAnExtraScope` ← locks in the bug fix
- `NestedScopes_DisposeInLifoOrder_RestoreCorrectly`

The scope stack is process-wide static state, so each test captures the baseline `Current` scope on entry and asserts the stack is restored to it — keeping the tests independent of execution order.

## Test plan

- [x] `msbuild InfoBox.csproj` (.NET 4.8) — builds
- [x] `dotnet test InfoBoxCore.Tests` — **88 / 88 pass** (was 84)
- [ ] Azure DevOps CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)