### PR TITLE
Designer: fall back to style defaults when only one custom color is picked

### DIFF
--- a/InfoBox.Designer/InformationBoxDesigner.cs
+++ b/InfoBox.Designer/InformationBoxDesigner.cs
@@ -563,6 +563,8 @@ namespace InfoBox.Designer
         /// <see cref="DesignParameters"/> breaks the Modern style rendering (the form's
         /// background becomes effectively transparent) and produces misleading
         /// <c>Color.FromArgb(0,0,0)</c> output in the "Generate code" preview.
+        /// When only one of the two colors is picked, the other falls back to the active
+        /// style's default so the unset color renders normally instead of as Color.Empty.
         /// </remarks>
         private DesignParameters GetDesign()
         {
@@ -576,7 +578,25 @@ namespace InfoBox.Designer
                 return null;
             }
 
-            return new DesignParameters(this.formColor, this.barsColor);
+            // Defaults mirror InformationBoxForm.SetWindowStyle so a half-filled design
+            // looks identical to the style's default for the color the user left unset.
+            Color defaultForm;
+            Color defaultBars;
+            if (this.GetStyle() == InformationBoxStyle.Modern)
+            {
+                defaultForm = Color.Silver;
+                defaultBars = Color.Black;
+            }
+            else
+            {
+                defaultForm = SystemColors.Control;
+                defaultBars = SystemColors.Control;
+            }
+
+            Color resolvedForm = this.formColor.IsEmpty ? defaultForm : this.formColor;
+            Color resolvedBars = this.barsColor.IsEmpty ? defaultBars : this.barsColor;
+
+            return new DesignParameters(resolvedForm, resolvedBars);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Follow-up to #83. That PR fixed "Custom colors checked but **nothing** picked" (→ returns `null`). This PR handles the remaining **partial** case: when the user picks only **one** of the two colors (Bars *or* Form), the other was still forwarded to `DesignParameters` as `Color.Empty`, which has `A=0` and renders as a transparent panel.

## Fix

`GetDesign()` now fills the unset color with the **active style's default**, mirroring `InformationBoxForm.SetWindowStyle`:

| Style | form default | bars default |
|---|---|---|
| Modern | `Color.Silver` | `Color.Black` |
| Standard | `SystemColors.Control` | `SystemColors.Control` |

So picking only a Bars color keeps the form background at the style default (instead of transparent), and the generated code reflects real colors rather than `Color.FromArgb(0, 0, 0)`.

The both-empty and both-picked cases are unchanged (both-empty still returns `null`).

## Test plan

- [x] `msbuild InfoBox.Designer.csproj` (.NET 4.8) — builds
- [x] Manual smoke test in the designer:
  - Custom colors ON, pick **only Bars** (Modern) → form stays silver, bars = picked, no transparency
  - Custom colors ON, pick **only Form** (Standard) → bars stays system-gray (flat), form = picked
  - Both picked → unchanged from before
  - Neither picked → no `design:` argument generated (from #83)

> Note: the designer form isn't part of the unit-test surface (the designer tests cover the code *generators*, not the WinForms form), so this relies on the build + a manual check — same as #81 and #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)