### PR TITLE
Modernize the build: dotnet-based azure-pipelines.yml + dotnet-first docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,27 +8,26 @@ InformationBox is a Windows Forms library providing a customizable alternative t
 
 ## Build Commands
 
-**IMPORTANT:** Always use the full MSBuild path when building this project. MSBuild is located at:
-`P:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\msbuild.exe`
-
-The solution multi-targets .NET Framework 4.8 and .NET 8/9/10. As of the InfoBoxCore consolidation, **`dotnet build InfoBox.sln` works** for the whole solution; VS MSBuild remains the canonical path (and is what Azure DevOps CI uses via `VSBuild@1`):
+The solution multi-targets .NET Framework 4.8 and .NET 8/9/10. Since the InfoBoxCore consolidation (net48 folded into the SDK-style `InfoBoxCore.csproj`), **`dotnet` is the primary build tool** and works for the whole solution:
 
 ```bash
 # Build all projects
-"P:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\msbuild.exe" InfoBox.sln
+dotnet build InfoBox.sln -c Release
 
-# Build with specific configuration
-"P:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\msbuild.exe" InfoBox.sln -p:Configuration=Release
+# Rebuild all (force a full, non-incremental build)
+dotnet build InfoBox.sln -c Release --no-incremental
 
-# Rebuild all (clean + build)
-"P:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\msbuild.exe" InfoBox.sln -t:Rebuild
+# Run all tests (both InfoBoxCore.Tests and InfoBoxCore.Designer.Tests)
+dotnet test InfoBox.sln -c Release
 
-# Run tests
-dotnet test
-
-# Pack NuGet package
+# Pack the NuGet package (multi-target; pulls all 4 TFMs from InfoBoxCore/bin/Release/)
 nuget pack InfoBox/InfoBox.nuspec
 ```
+
+CI is the dotnet-based pipeline in `azure-pipelines.yml` (no Visual Studio dependency).
+
+VS MSBuild still works if you specifically need it (it is **not** required):
+`"P:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\msbuild.exe" InfoBox.sln -p:Configuration=Release`
 
 ## Project Structure
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,89 @@
+# Modern, dotnet-based CI pipeline for InformationBox.
+#
+# Replaces the legacy classic (portal-defined) pipeline that used VSBuild@1 +
+# VSTest@3 + the Visual Studio Test Platform Installer. Those required Visual
+# Studio / MSBuild to be present on the build agent. Since the InfoBoxCore
+# consolidation (InfoBox.csproj removed, net48 folded into the SDK-style
+# InfoBoxCore.csproj), `dotnet build` / `dotnet test` work for the whole
+# solution, so the VS dependency is no longer needed.
+#
+# To adopt this: in Azure DevOps, create a new YAML pipeline pointing at this
+# file, confirm a green run, then disable/delete the old classic pipeline
+# (definition id 2, "InformationBox").
+
+trigger:
+  branches:
+    include:
+      - master
+      - '*'
+
+pr:
+  branches:
+    include:
+      - master
+
+pool:
+  # Windows is required: the library targets net48 and uses Windows Forms.
+  vmImage: 'windows-latest'
+
+variables:
+  buildConfiguration: 'Release'
+  solution: 'InfoBox.sln'
+
+steps:
+  # Installs the SDK pinned by global.json. Once the global.json pin is removed
+  # (it only existed to keep VSBuild@1 / MSBuild 17.x happy - irrelevant now that
+  # dotnet uses its own bundled MSBuild), replace `useGlobalJson: true` with
+  # `version: '10.x'`.
+  - task: UseDotNet@2
+    displayName: 'Use .NET SDK (from global.json)'
+    inputs:
+      packageType: sdk
+      useGlobalJson: true
+
+  # SonarCloud begin. Mirrors the classic pipeline's settings.
+  # NOTE: confirm the service-connection reference. The classic pipeline used the
+  # connection with id 4f97f462-c9ce-49e3-a068-45d12d5fc407; reference it here by
+  # its display name (recommended) or by that id.
+  - task: SonarCloudPrepare@4
+    displayName: 'Prepare analysis on SonarCloud'
+    inputs:
+      SonarCloud: 'SonarCloud'        # <-- set to your SonarCloud service connection name
+      organization: 'johannblais'
+      scannerMode: 'dotnet'
+      projectKey: 'JohannBlais_InformationBox'
+      projectName: 'InformationBox'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore'
+    inputs:
+      command: 'restore'
+      projects: '$(solution)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build'
+    inputs:
+      command: 'build'
+      projects: '$(solution)'
+      arguments: '--configuration $(buildConfiguration) --no-restore'
+
+  # `dotnet test` on the solution runs both InfoBoxCore.Tests and
+  # InfoBoxCore.Designer.Tests. XPlat Code Coverage produces a Cobertura report;
+  # SonarCloud picks it up automatically via the dotnet scanner.
+  - task: DotNetCoreCLI@2
+    displayName: 'Test'
+    inputs:
+      command: 'test'
+      projects: '$(solution)'
+      arguments: '--configuration $(buildConfiguration) --no-build --collect "XPlat Code Coverage"'
+      publishTestResults: true
+
+  - task: SonarCloudAnalyze@4
+    displayName: 'Run Code Analysis'
+
+  # Optional but recommended: surfaces the SonarCloud Quality Gate result on the
+  # build/PR. The classic pipeline did not include this step - remove if undesired.
+  - task: SonarCloudPublish@4
+    displayName: 'Publish Quality Gate Result'
+    inputs:
+      pollingTimeoutSec: '300'


### PR DESCRIPTION
## Summary

Now that `dotnet build` / `dotnet test InfoBox.sln` work for the whole solution (after the InfoBoxCore consolidation in #90), the build no longer needs Visual Studio / MSBuild on the agent. This introduces a modern, dotnet-based pipeline-as-code and updates the local-build docs.

### `azure-pipelines.yml` (new)

A YAML replacement for the legacy **classic** (portal-defined) pipeline. It drops the VS-dependent tasks:

| Classic pipeline | New YAML |
|---|---|
| `Use .NET Core sdk 10.x` (UseDotNet@2, useGlobalJson) | `UseDotNet@2` (useGlobalJson) — unchanged |
| `Visual Studio Test Platform Installer` | **removed** (not needed by `dotnet test`) |
| `Use NuGet` + `NuGet restore` | `DotNetCoreCLI@2 restore` |
| `SonarCloudPrepare@4` (scannerMode dotnet) | same |
| `VSBuild@1` (vsVersion 17.0) | `DotNetCoreCLI@2 build` |
| `VSTest@3` (toolsInstaller) | `DotNetCoreCLI@2 test` (`--collect "XPlat Code Coverage"`) |
| `SonarCloudAnalyze@4` | same |
| — | `SonarCloudPublish@4` (optional, added — quality gate) |

Verified locally: `dotnet build InfoBox.sln` and `dotnet test InfoBox.sln` (88 + 8 tests) both succeed. YAML syntax validated.

### `CLAUDE.md`

Build docs now lead with `dotnet build` / `dotnet test` / `nuget pack`; the hardcoded VS MSBuild path is demoted to an optional fallback.

## What you need to do (portal — I can't do or test these)

1. Create a **new YAML pipeline** in Azure DevOps pointing at `azure-pipelines.yml`.
2. Confirm the **SonarCloud service-connection name** in the YAML (the placeholder `'SonarCloud'`) — the classic pipeline used connection id `4f97f462-...`; YAML references it by display name.
3. Run it; iterate on the SonarCloud coverage path if needed (the dotnet scanner reads the Cobertura report from `XPlat Code Coverage`).
4. Once green, **disable/delete the classic pipeline** (definition id 2).
5. Then we can **remove the `global.json` pin** and switch `UseDotNet@2` to `version: '10.x'` (separate small PR — the pin only existed for VSBuild@1/MSBuild 17.x).

## Notes

- The classic pipeline's **pack/publish steps are disabled** (packaging is elsewhere — a release pipeline). Those disabled steps still reference the old `InfoBox\bin\...\InfoBox.dll` path (removed in #90); whatever release process packs the nupkg should point at `InfoBoxCore\bin\Release\net48\` and use `InfoBox/InfoBox.nuspec`.
- The classic `Update AssemblyInfo` version-stamping task is **not** reproduced (it only matters for packaging, which isn't in CI). Can be added back if desired.

**Stacked on #91 → #90.** Merge order: #90, then #91, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)